### PR TITLE
Corrige e torna resiliente a integracao Sysfeed 

### DIFF
--- a/src/main/kotlin/br/andrew/sap/services/sysfeed/SysfeedProductionOrderService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/sysfeed/SysfeedProductionOrderService.kt
@@ -4,6 +4,7 @@ import br.andrew.sap.infrastructure.odata.Parameter
 import br.andrew.sap.model.sysfeed.SysfeedProductionOrderPending
 import br.andrew.sap.model.sysfeed.SysfeedProductionOrderRequest
 import br.andrew.sap.services.abstracts.SqlQueriesService
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
 import java.math.RoundingMode
@@ -14,10 +15,20 @@ import java.time.format.DateTimeFormatter
 class SysfeedProductionOrderService(
     private val sqlQueriesService: SqlQueriesService
 ) {
+    private val logger = LoggerFactory.getLogger(SysfeedProductionOrderService::class.java)
     private val outputDateFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
 
+    // Cada ordem e montada isoladamente: uma linha invalida e ignorada e reportada,
+    // sem derrubar o lote inteiro das ordens validas.
     fun getPendingPayloads(dataCorte: String): List<SysfeedProductionOrderRequest> {
-        return getPendingRows(resolveStartDate(dataCorte)).map { buildPayload(it) }
+        return getPendingRows(resolveStartDate(dataCorte)).mapNotNull { pending ->
+            try {
+                buildPayload(pending)
+            } catch (e: Exception) {
+                logger.warn("SYSFEED_ORDEM_PRODUCAO_IGNORADA docEntry={} motivo={}", pending.DocEntry, e.message)
+                null
+            }
+        }
     }
 
     // dataCorte vem sempre do integrador; sem ele nao ha o que consultar.
@@ -44,9 +55,10 @@ class SysfeedProductionOrderService(
 
         val quantidadeTotal = normalizeNumeric(pending.Quantidade)
         validateNotZero("PlannedQty", quantidadeTotal)
-        val tamanhoBatelada = normalizeNumeric(pending.QuantBat ?: pending.Quantidade)
-        validateNotZero("U_LbrOne_Batelada", tamanhoBatelada)
-        val quantidadeBateladas = divideQuantity(quantidadeTotal, tamanhoBatelada)
+        // U_LbrOne_Batelada ja e o NUMERO de bateladas (nao o tamanho).
+        val quantidadeBateladas = normalizeNumeric(pending.QuantBat ?: "1")
+        validateNotZero("U_LbrOne_Batelada", quantidadeBateladas)
+        val tamanhoBatelada = divideQuantity(quantidadeTotal, quantidadeBateladas)
         val descricao = pending.DescricaoOrdemProducao
             ?.trim()
             ?.takeIf { it.isNotBlank() }
@@ -59,11 +71,11 @@ class SysfeedProductionOrderService(
             codIntOrdemProducao = codOrdemProducao,
             codFormula = codFormula,
             codIntFormula = codFormula,
-            // SYSFEED: Quantidade = total da OP, QuantBat = tamanho da batelada, TotalQuantidade = nro de bateladas.
-            quantidade = quantidadeTotal,
+            // SYSFEED: Quantidade = tamanho da batelada; QuantBat e TotalQuantidade = numero de bateladas.
+            quantidade = tamanhoBatelada,
             prioridade = "1",
             totalQuantidade = quantidadeBateladas,
-            quantBat = tamanhoBatelada,
+            quantBat = quantidadeBateladas,
             dataEntradaOP = formatDate(pending.DataEntradaOP),
             dataEntregaProducao = formatDate(pending.DataEntregaProducao),
             tipoOrdemProducao = "A",
@@ -119,12 +131,18 @@ class SysfeedProductionOrderService(
 
     private fun formatDate(value: String?): String? {
         val date = value?.trim()?.takeIf { it.isNotBlank() } ?: return null
-        val normalized = if (date.matches(Regex("\\d{8}"))) {
-            "${date.substring(0, 4)}-${date.substring(4, 6)}-${date.substring(6, 8)}"
-        } else {
-            date.take(10)
+        return try {
+            val normalized = if (date.matches(Regex("\\d{8}"))) {
+                "${date.substring(0, 4)}-${date.substring(4, 6)}-${date.substring(6, 8)}"
+            } else {
+                date.take(10)
+            }
+            LocalDate.parse(normalized).format(outputDateFormatter)
+        } catch (e: Exception) {
+            // Data invalida na origem nao deve derrubar a ordem: apenas omitimos o campo (opcional) e registramos.
+            logger.warn("SYSFEED_ORDEM_PRODUCAO_DATA_INVALIDA valor={} motivo={}", value, e.message)
+            null
         }
-        return LocalDate.parse(normalized).format(outputDateFormatter)
     }
 }
 

--- a/src/main/kotlin/br/andrew/sap/services/sysfeed/SysfeedReceivingOrderService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/sysfeed/SysfeedReceivingOrderService.kt
@@ -4,6 +4,7 @@ import br.andrew.sap.infrastructure.odata.Parameter
 import br.andrew.sap.model.sysfeed.SysfeedReceivingOrderRequest
 import br.andrew.sap.model.sysfeed.SysfeedReceivingPending
 import br.andrew.sap.services.abstracts.SqlQueriesService
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
@@ -17,7 +18,11 @@ class SysfeedReceivingOrderService(
     private val supplierService: SysfeedSupplierService,
     @Value("\${sysfeed.recebimento.cod-prod-default:1}") private val defaultCodProd: String
 ) {
+    private val logger = LoggerFactory.getLogger(SysfeedReceivingOrderService::class.java)
+
     // dataCorte e usages vem sempre do integrador; sem eles nao ha o que consultar.
+    // Cada linha e montada isoladamente: uma linha invalida e ignorada e reportada,
+    // sem derrubar o lote inteiro das linhas validas.
     fun getPendingPayloads(
         dataCorte: String,
         usages: List<Int>
@@ -25,7 +30,17 @@ class SysfeedReceivingOrderService(
         val startDate = resolveStartDate(dataCorte)
         return resolveUsages(usages)
             .flatMap { getPendingRows(startDate, it) }
-            .map { buildPayload(it) }
+            .mapNotNull { pending ->
+                try {
+                    buildPayload(pending)
+                } catch (e: Exception) {
+                    logger.warn(
+                        "SYSFEED_ORDEM_RECEBIMENTO_IGNORADA docEntry={} lineNum={} motivo={}",
+                        pending.DocEntry, pending.LineNum, e.message
+                    )
+                    null
+                }
+            }
     }
 
     private fun resolveStartDate(dataCorte: String): String {
@@ -104,6 +119,8 @@ class SysfeedReceivingOrderService(
             val date = LocalDate.parse(sapDate.take(10))
             date.format(DateTimeFormatter.ofPattern("dd/MM/yyyy")) + " 00:00:00"
         } catch (e: Exception) {
+            // Data invalida na origem: omitimos o campo (opcional) e registramos, em vez de falhar silenciosamente.
+            logger.warn("SYSFEED_ORDEM_RECEBIMENTO_DATA_INVALIDA valor={} motivo={}", sapDate, e.message)
             null
         }
     }

--- a/src/main/kotlin/br/andrew/sap/services/sysfeed/SysfeedStatusService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/sysfeed/SysfeedStatusService.kt
@@ -55,31 +55,41 @@ class SysfeedStatusService(
 
         val agora = LocalDateTime.now()
         // DtIntegracao/HrIntegracao marcam envio concluido com sucesso e viram a trava anti-reenvio
-        // (a view de pendentes exige DtIntegracao NULL). So gravamos em status de sucesso para nao
-        // bloquear o reprocessamento de ERRO/PARCIAL apos o status voltar para PENDENTE.
+        // (a view de pendentes exige DtIntegracao NULL). Em status de sucesso gravamos a trava;
+        // em qualquer outro status (PENDENTE/ERRO/PARCIAL) a limpamos explicitamente, senao um item
+        // reenviado continuaria fora da view de pendentes e nunca voltaria para a fila.
         val marcarIntegracao = status in successStatuses
-        val payload = mutableMapOf<String, Any>("U_sysfeed_status" to status)
+        val payload = mutableMapOf<String, Any?>("U_sysfeed_status" to status)
         when (update.tipo) {
             SysfeedStatusTarget.FORNECEDOR -> businessPartnersService.update(payload, "'$codigo'")
             SysfeedStatusTarget.ORDEM_RECEBIMENTO -> {
                 codigo.toIntOrNull() ?: throw SysfeedStatusException("DocEntry invalido: $codigo")
-                if (marcarIntegracao) {
-                    payload["U_LbrOne_DtIntegracao"] = agora.format(dtIntegracaoFormatter)
-                    payload["U_LbrOne_HrIntegracao"] = agora.hour * 100 + agora.minute
-                }
+                aplicarTravaIntegracao(payload, marcarIntegracao, agora)
                 purchaseInvoiceService.update(payload, codigo)
             }
             SysfeedStatusTarget.ORDEM_PRODUCAO -> {
                 codigo.toIntOrNull() ?: throw SysfeedStatusException("DocEntry invalido: $codigo")
-                if (marcarIntegracao) {
-                    payload["U_LbrOne_DtIntegracao"] = agora.format(dtIntegracaoFormatter)
-                    payload["U_LbrOne_HrIntegracao"] = agora.hour * 100 + agora.minute
-                }
+                aplicarTravaIntegracao(payload, marcarIntegracao, agora)
                 update.obs?.trim()?.takeIf { it.isNotBlank() }?.let {
                     payload["U_LbrOne_Obs_Integracao"] = it
                 }
                 productionOrdersService.update(payload, codigo)
             }
+        }
+    }
+
+    // Sucesso grava a trava anti-reenvio; nao-sucesso a limpa (null) para devolver o item a fila.
+    private fun aplicarTravaIntegracao(
+        payload: MutableMap<String, Any?>,
+        marcarIntegracao: Boolean,
+        agora: LocalDateTime
+    ) {
+        if (marcarIntegracao) {
+            payload["U_LbrOne_DtIntegracao"] = agora.format(dtIntegracaoFormatter)
+            payload["U_LbrOne_HrIntegracao"] = agora.hour * 100 + agora.minute
+        } else {
+            payload["U_LbrOne_DtIntegracao"] = null
+            payload["U_LbrOne_HrIntegracao"] = null
         }
     }
 }

--- a/src/test/kotlin/br/andrew/sap/services/sysfeed/SysfeedProductionOrderServiceTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/sysfeed/SysfeedProductionOrderServiceTest.kt
@@ -52,10 +52,10 @@ class SysfeedProductionOrderServiceTest {
         assertEquals("12345", payload.codIntOrdemProducao)
         assertEquals("100", payload.codFormula)
         assertEquals("100", payload.codIntFormula)
-        assertEquals("1000", payload.quantidade)
+        assertEquals("2000", payload.quantidade)
         assertEquals("1", payload.prioridade)
-        assertEquals("4", payload.totalQuantidade)
-        assertEquals("250", payload.quantBat)
+        assertEquals("10", payload.totalQuantidade)
+        assertEquals("10", payload.quantBat)
         assertEquals("A", payload.tipoOrdemProducao)
         assertEquals("ORDEM DE PRODUCAO 12345", payload.descricaoOrdemProducao)
         assertEquals("18/06/2026", payload.dataEntradaOP)
@@ -108,13 +108,13 @@ class SysfeedProductionOrderServiceTest {
         descricao: String? = null,
         dataEntrada: String? = "2026-06-18",
         dataEntrega: String? = "2026-06-19",
-        quantBat: String? = "250"
+        quantBat: String? = "10"
     ): SysfeedProductionOrderPending {
         return SysfeedProductionOrderPending(
             DocEntry = docEntry,
             DocNum = "12345",
             ItemCode = "PA0001",
-            Quantidade = "1000.000000",
+            Quantidade = "20000.000000",
             DataEntradaOP = dataEntrada,
             DataEntregaProducao = dataEntrega,
             DescricaoOrdemProducao = descricao,

--- a/src/test/kotlin/br/andrew/sap/services/sysfeed/SysfeedStatusServiceTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/sysfeed/SysfeedStatusServiceTest.kt
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.check
@@ -35,12 +36,15 @@ class SysfeedStatusServiceTest {
         assertEquals(3, result.size)
         assertTrue(result.all { it.success })
         verify(businessPartnersService).update(eq(mapOf("U_sysfeed_status" to "ENVIADO")), eq("'FOR0002977'"))
-        // ERRO nao e sucesso: nao deve marcar DtIntegracao (senao travaria o reprocessamento).
+        // ERRO nao e sucesso: limpa DtIntegracao/HrIntegracao (null) para nao travar o reprocessamento.
+        // Omitir as chaves deixaria o valor antigo no PATCH; por isso enviamos null explicito.
         verify(purchaseInvoiceService).update(
-            check<Map<String, Any>> {
+            check<Map<String, Any?>> {
                 assertEquals("ERRO", it["U_sysfeed_status"])
-                assertFalse(it.containsKey("U_LbrOne_DtIntegracao"))
-                assertFalse(it.containsKey("U_LbrOne_HrIntegracao"))
+                assertTrue(it.containsKey("U_LbrOne_DtIntegracao"))
+                assertNull(it["U_LbrOne_DtIntegracao"])
+                assertTrue(it.containsKey("U_LbrOne_HrIntegracao"))
+                assertNull(it["U_LbrOne_HrIntegracao"])
                 assertFalse(it.containsKey("U_LbrOne_Obs_Integracao"))
             },
             eq("144594")
@@ -75,12 +79,14 @@ class SysfeedStatusServiceTest {
             },
             eq("144594")
         )
-        // PARCIAL nao trava: sem DtIntegracao, segue reprocessavel.
+        // PARCIAL nao e sucesso: limpa a trava (DtIntegracao/HrIntegracao = null) para seguir reprocessavel.
         verify(productionOrdersService).update(
-            check<Map<String, Any>> {
+            check<Map<String, Any?>> {
                 assertEquals("PARCIAL", it["U_sysfeed_status"])
-                assertFalse(it.containsKey("U_LbrOne_DtIntegracao"))
-                assertFalse(it.containsKey("U_LbrOne_HrIntegracao"))
+                assertTrue(it.containsKey("U_LbrOne_DtIntegracao"))
+                assertNull(it["U_LbrOne_DtIntegracao"])
+                assertTrue(it.containsKey("U_LbrOne_HrIntegracao"))
+                assertNull(it["U_LbrOne_HrIntegracao"])
             },
             eq("12345")
         )


### PR DESCRIPTION
…o, status)

- Ordem de producao: U_LbrOne_Batelada e o NUMERO de bateladas (nao o tamanho); quantidade passa a ser o tamanho da batelada e totalQuantidade/quantBat o numero.
- Producao e recebimento: cada linha e montada isoladamente (mapNotNull + try/catch); uma linha invalida e ignorada e logada, sem derrubar o lote inteiro das validas.
- Datas invalidas na origem sao omitidas e registradas, em vez de falhar.
- Status: limpa U_LbrOne_DtIntegracao/HrIntegracao em status nao-sucesso (PENDENTE/ERRO/PARCIAL) para devolver o item a fila de reprocessamento.
- Ajusta testes de producao e status.