### PR TITLE
fix: gera pix na uzzipay antes de criar o adiantamento

### DIFF
--- a/src/main/kotlin/br/andrew/sap/controllers/PixController.kt
+++ b/src/main/kotlin/br/andrew/sap/controllers/PixController.kt
@@ -83,45 +83,47 @@ class PixController(
                 ).take(254)
         adiantamento.U_TX_DocEntryRef = pixRequest.docEntry
         adiantamento.U_TX_DocTypeRef = pixRequest.documentTypes?.value
-        val adiantamentoComParcelas = adiantamentoService.getById(
-            adiantamentoService.save(adiantamento).tryGetValue<DownPayment>().docEntry ?: throw Exception("Falha ao obter docEntry do adiantamento gerado")
-        ).tryGetValue<DownPayment>()
-        return try {
-            atualizarPixAdiantamento(adiantamentoComParcelas, pixRequest)
+        val immediate = pixRequest.getImmediateRequest()
+        val dadosPix = pixDynamicService.genereateFor(immediate)
+        val docEntry = try {
+            adiantamentoService.save(adiantamento).tryGetValue<DownPayment>().docEntry
+                ?: throw Exception("Falha ao obter docEntry do adiantamento gerado")
         } catch (e: Exception) {
-            cancelarAdiantamentoGerado(adiantamentoComParcelas, e)
+            logger.error("Pix {} gerado na uzzipay mas o adiantamento nao foi criado", dadosPix.data.reference, e)
+            throw e
+        }
+        return try {
+            val adiantamentoComParcelas = adiantamentoService.getById(docEntry).tryGetValue<DownPayment>()
+            val installmentAtualizado = adiantamentoComParcelas.documentInstallments?.firstOrNull()
+                ?.setPix(immediate, dadosPix)
+                ?: throw Exception("Parcela do adiantamento não encontrada para associar o pix")
+            adiantamentoService.updatePixInstallments(docEntry, listOf(installmentAtualizado))
+            installmentAtualizado.DocEntry = docEntry
+            PixGeradoResponse(installmentAtualizado, 0.0)
+        } catch (e: Exception) {
+            estornarAdiantamentoGerado(docEntry, e)
             throw e
         }
     }
 
-    private fun cancelarAdiantamentoGerado(adiantamento: DownPayment, erroOriginal: Exception) {
-        val docEntry = adiantamento.docEntry
-        if(docEntry == null) {
-            logger.error("Falha ao gerar PIX e nao foi possivel cancelar o adiantamento sem DocEntry", erroOriginal)
-            return
-        }
+    private fun estornarAdiantamentoGerado(docEntry: Int, erroOriginal: Exception) {
+        var referencia = docEntry.toString()
         try {
-            adiantamentoService.cancel(docEntry.toString())
-        } catch (cancelError: Exception) {
-            erroOriginal.addSuppressed(cancelError)
-            logger.error("Falha ao cancelar adiantamento {} apos erro ao gerar PIX", docEntry, cancelError)
+            val adiantamento = adiantamentoService.getById(docEntry).tryGetValue<DownPayment>()
+            referencia = adiantamento.docNum ?: referencia
+            adiantamentoService.estornarPorDevolucao(
+                adiantamento,
+                "Estorno automatico por falha ao gravar dados do PIX."
+            )
+        } catch (estornoError: Exception) {
+            erroOriginal.addSuppressed(estornoError)
+            logger.error("Falha ao estornar adiantamento {} apos erro na geracao do pix", docEntry, estornoError)
+            throw Exception(
+                "${erroOriginal.message}. Nao foi possivel estornar o adiantamento $referencia automaticamente," +
+                        " faca a devolucao manual antes de gerar um novo PIX.",
+                erroOriginal
+            )
         }
-    }
-
-    private fun atualizarPixAdiantamento(
-        adiantamento: DownPayment,
-        pixRequest: PixRequestAdiantamento
-    ): PixGeradoResponse {
-        val immediate = pixRequest.getImmediateRequest(adiantamento)
-        val dadosPix = pixDynamicService.genereateFor(immediate)
-        val installmentAtualizado = adiantamento.setPix(immediate, dadosPix)
-            ?: throw Exception("Parcela do adiantamento não encontrada para associar o pix")
-        adiantamentoService.updatePixInstallments(
-            adiantamento.docEntry ?: throw Exception("Falha ao obter docEntry do adiantamento"),
-            listOf(installmentAtualizado)
-        )
-        installmentAtualizado.DocEntry = adiantamento.docEntry
-        return PixGeradoResponse(installmentAtualizado, 0.0)
     }
 
     @GetMapping("gerar-chave/docType/{pixDocType}/docEntry/{docEntry}/parcela/{parcela}")

--- a/src/main/kotlin/br/andrew/sap/services/document/DownPaymentService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/document/DownPaymentService.kt
@@ -261,7 +261,10 @@ class DownPaymentService(env: SapEnvrioment,
         return accountsReceivableService.baixaPixBy(downPayment, installment, transaction, conta)
     }
 
-    fun estornarPorDevolucao(downPayment: DownPayment): CreditNotes {
+    fun estornarPorDevolucao(
+        downPayment: DownPayment,
+        motivo: String = "Estorno automatico de adiantamento PIX expirado."
+    ): CreditNotes {
         val docEntry = downPayment.docEntry ?: throw Exception("DocEntry do adiantamento nao pode ser nulo")
         val devolucaoExistente = sqlQueriesService
             .execute("devolucao-adiantamento.sql", Parameter("docEntry", docEntry))
@@ -274,7 +277,7 @@ class DownPaymentService(env: SapEnvrioment,
 
         val devolucao = CreditNotes(downPayment).also {
             val referencia = downPayment.docNum ?: docEntry.toString()
-            it.comments = "Estorno automatico de adiantamento PIX expirado. Adiantamento $referencia"
+            it.comments = "$motivo Adiantamento $referencia"
             it.journalMemo = it.comments
             it.U_TX_DocEntryRef = docEntry
             it.U_TX_DocTypeRef = downPayment.docObjectCode?.value

--- a/src/test/kotlin/br/andrew/sap/controllers/PixControllerTest.kt
+++ b/src/test/kotlin/br/andrew/sap/controllers/PixControllerTest.kt
@@ -1,0 +1,162 @@
+package br.andrew.sap.controllers
+
+import br.andrew.sap.infrastructure.configurations.uzzipay.UzziPayEnvrioment
+import br.andrew.sap.infrastructure.odata.Filter
+import br.andrew.sap.infrastructure.odata.OData
+import br.andrew.sap.model.PixRequestAdiantamento
+import br.andrew.sap.model.authentication.User
+import br.andrew.sap.model.authentication.UserOriginEnum
+import br.andrew.sap.model.sap.documents.DocumentTypes
+import br.andrew.sap.model.uzzipay.ContaUzziPayPix
+import br.andrew.sap.model.uzzipay.DataRetonroPixQrCode
+import br.andrew.sap.model.uzzipay.RequestPixImmediate
+import br.andrew.sap.model.uzzipay.RetonroPixQrCode
+import br.andrew.sap.services.document.DownPaymentService
+import br.andrew.sap.services.document.InvoiceService
+import br.andrew.sap.services.uzzipay.DynamicPixQrCodeService
+import br.andrew.sap.services.uzzipay.PixPaymentVerificationService
+import br.andrew.sap.services.uzzipay.TransactionsPixService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.inOrder
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+
+class PixControllerTest {
+
+    private val pixDynamicService = mock(DynamicPixQrCodeService::class.java)
+    private val adiantamentoService = mock(DownPaymentService::class.java)
+
+    private val controller = PixController(
+        mock(TransactionsPixService::class.java),
+        mock(InvoiceService::class.java),
+        mock(PixPaymentVerificationService::class.java),
+        pixDynamicService,
+        adiantamentoService,
+        "PIX-ITEM",
+        66,
+        0.0
+    )
+
+    private val user = User(
+        "1",
+        "Tester",
+        UserOriginEnum.EmployeesInfo,
+        "tester",
+        bussinesPlace = listOf()
+    )
+
+    @BeforeEach
+    fun setup() {
+        PixRequestAdiantamento.clearContasConfiguradas()
+        val conta = ContaUzziPayPix().also {
+            it.idFilial = 3
+            it.cnpj = "12345678000190"
+            it.chavePix = "PIX-OK"
+            it.privateKey = "private-key"
+            it.consulta = "consulta"
+            it.contaContabilBanco = "conta"
+        }
+        PixRequestAdiantamento.setUzziPayEnvrioment(UzziPayEnvrioment().also { it.contas = listOf(conta) })
+        whenever(adiantamentoService.get(any<Filter>())).thenReturn(odata(listOf<Any>()))
+    }
+
+    @Test
+    fun falhaNaUzzipayNaoCriaAdiantamento() {
+        whenever(pixDynamicService.genereateFor(any<RequestPixImmediate>()))
+            .thenThrow(RuntimeException("Falha de comunicação com a uzzipay"))
+
+        val erro = assertThrows<RuntimeException> { controller.gerarChavePixByValor(request(), user) }
+
+        assertTrue((erro.message ?: "").contains("uzzipay"))
+        verify(adiantamentoService, never()).save(any())
+    }
+
+    @Test
+    fun fluxoFelizGeraPixAntesDeSalvarAdiantamento() {
+        whenever(pixDynamicService.genereateFor(any<RequestPixImmediate>())).thenReturn(retornoPix())
+        whenever(adiantamentoService.save(any())).thenReturn(odataAdiantamentoSalvo())
+        whenever(adiantamentoService.getById(321)).thenReturn(odataAdiantamentoComParcelas())
+
+        val response = controller.gerarChavePixByValor(request(), user)
+
+        assertEquals("ref-123", response.U_pix_reference)
+        assertEquals(321, response.docEntry)
+        val ordem = inOrder(pixDynamicService, adiantamentoService)
+        ordem.verify(pixDynamicService).genereateFor(any<RequestPixImmediate>())
+        ordem.verify(adiantamentoService).save(any())
+        verify(adiantamentoService).updatePixInstallments(eq(321), any())
+        verify(adiantamentoService, never()).estornarPorDevolucao(any(), any())
+    }
+
+    @Test
+    fun falhaAoGravarPixNaParcelaEstornaPorDevolucao() {
+        whenever(pixDynamicService.genereateFor(any<RequestPixImmediate>())).thenReturn(retornoPix())
+        whenever(adiantamentoService.save(any())).thenReturn(odataAdiantamentoSalvo())
+        whenever(adiantamentoService.getById(321)).thenReturn(odataAdiantamentoComParcelas())
+        doThrow(RuntimeException("SAP retornou sucesso, mas não persistiu os dados PIX"))
+            .whenever(adiantamentoService).updatePixInstallments(eq(321), any())
+
+        val erro = assertThrows<RuntimeException> { controller.gerarChavePixByValor(request(), user) }
+
+        assertTrue((erro.message ?: "").contains("não persistiu"))
+        verify(adiantamentoService)
+            .estornarPorDevolucao(any(), eq("Estorno automatico por falha ao gravar dados do PIX."))
+    }
+
+    @Test
+    fun falhaNoEstornoOrientaDevolucaoManualComDocNum() {
+        whenever(pixDynamicService.genereateFor(any<RequestPixImmediate>())).thenReturn(retornoPix())
+        whenever(adiantamentoService.save(any())).thenReturn(odataAdiantamentoSalvo())
+        whenever(adiantamentoService.getById(321)).thenReturn(odataAdiantamentoComParcelas())
+        doThrow(RuntimeException("SAP retornou sucesso, mas não persistiu os dados PIX"))
+            .whenever(adiantamentoService).updatePixInstallments(eq(321), any())
+        whenever(adiantamentoService.estornarPorDevolucao(any(), any()))
+            .thenThrow(RuntimeException("sem permissao"))
+
+        val erro = assertThrows<Exception> { controller.gerarChavePixByValor(request(), user) }
+
+        assertTrue((erro.message ?: "").contains("654"))
+        assertTrue((erro.message ?: "").contains("devolucao manual"))
+    }
+
+    private fun request(): PixRequestAdiantamento {
+        return PixRequestAdiantamento(
+            cardCode = "C-001",
+            valor = BigDecimal("82.00"),
+            idFilial = 3,
+            docEntry = 987,
+            documentTypes = DocumentTypes.oOrders
+        )
+    }
+
+    private fun retornoPix(): DataRetonroPixQrCode {
+        return DataRetonroPixQrCode(RetonroPixQrCode("pix-copia-cola", "https://pix", "ref-123", null))
+    }
+
+    private fun odataAdiantamentoSalvo(): OData {
+        return odata("""{"CardCode":"C-001","BPL_IDAssignedToInvoice":"3","DocEntry":321,"DocNum":"654"}""")
+    }
+
+    private fun odataAdiantamentoComParcelas(): OData {
+        return odata(
+            """{"CardCode":"C-001","BPL_IDAssignedToInvoice":"3","DocEntry":321,"DocNum":"654",
+                "DocumentInstallments":[{"InstallmentId":1,"DueDate":"2026-07-17","Total":82.0}]}"""
+        )
+    }
+
+    private fun odata(value: Any?): OData {
+        val backing = LinkedHashMap<String, Any?>()
+        backing["value"] = value
+        return OData(backing)
+    }
+}

--- a/src/test/kotlin/br/andrew/sap/services/document/DownPaymentServiceEstornoTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/document/DownPaymentServiceEstornoTest.kt
@@ -1,0 +1,121 @@
+package br.andrew.sap.services.document
+
+import br.andrew.sap.infrastructure.odata.OData
+import br.andrew.sap.infrastructure.odata.Parameter
+import br.andrew.sap.model.envrioments.SapEnvrioment
+import br.andrew.sap.model.sap.documents.CreditNotes
+import br.andrew.sap.model.sap.documents.DocumentTypes
+import br.andrew.sap.model.sap.documents.DownPayment
+import br.andrew.sap.model.sap.documents.base.Product
+import br.andrew.sap.services.AuthService
+import br.andrew.sap.services.BusinessPartnersService
+import br.andrew.sap.services.abstracts.SqlQueriesService
+import br.andrew.sap.services.bank.IncomingPaymentService
+import br.andrew.sap.services.bank.PaymentTermsTypesService
+import br.andrew.sap.services.batch.BatchService
+import br.andrew.sap.services.invent.BankPlusService
+import br.andrew.sap.services.journal.JournalEntriesService
+import br.andrew.sap.services.uzzipay.DynamicPixQrCodeService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import org.springframework.web.client.RestTemplate
+
+class DownPaymentServiceEstornoTest {
+
+    private val sqlQueriesService = mock(SqlQueriesService::class.java)
+    private val creditNotesService = mock(CreditNotesService::class.java)
+
+    private val service = DownPaymentService(
+        mock(SapEnvrioment::class.java),
+        sqlQueriesService,
+        mock(OrdersService::class.java),
+        mock(PaymentTermsTypesService::class.java),
+        mock(BankPlusService::class.java),
+        mock(AccountsReceivableService::class.java),
+        mock(IncomingPaymentService::class.java),
+        creditNotesService,
+        mock(BatchService::class.java),
+        mock(JournalEntriesService::class.java),
+        mock(DynamicPixQrCodeService::class.java),
+        mock(BusinessPartnersService::class.java),
+        "VF-ITEM",
+        66,
+        "none",
+        mock(RestTemplate::class.java),
+        mock(AuthService::class.java)
+    )
+
+    @Test
+    fun estornarPorDevolucaoUsaMotivoDefaultDePixExpirado() {
+        whenever(sqlQueriesService.execute(eq("devolucao-adiantamento.sql"), any<Parameter>()))
+            .thenReturn(null)
+        whenever(creditNotesService.save(any())).thenReturn(odataDevolucao())
+
+        service.estornarPorDevolucao(adiantamento())
+
+        val captor = argumentCaptor<CreditNotes>()
+        verify(creditNotesService).save(captor.capture())
+        assertEquals(
+            "Estorno automatico de adiantamento PIX expirado. Adiantamento 654",
+            captor.firstValue.comments
+        )
+    }
+
+    @Test
+    fun estornarPorDevolucaoComMotivoCustomizado() {
+        whenever(sqlQueriesService.execute(eq("devolucao-adiantamento.sql"), any<Parameter>()))
+            .thenReturn(null)
+        whenever(creditNotesService.save(any())).thenReturn(odataDevolucao())
+
+        service.estornarPorDevolucao(adiantamento(), "Estorno automatico por falha ao gravar dados do PIX.")
+
+        val captor = argumentCaptor<CreditNotes>()
+        verify(creditNotesService).save(captor.capture())
+        assertEquals(
+            "Estorno automatico por falha ao gravar dados do PIX. Adiantamento 654",
+            captor.firstValue.comments
+        )
+    }
+
+    @Test
+    fun estornarPorDevolucaoEhIdempotenteQuandoJaExisteDevolucao() {
+        whenever(sqlQueriesService.execute(eq("devolucao-adiantamento.sql"), any<Parameter>()))
+            .thenReturn(odata(listOf(mapOf("DocEntry" to 999))))
+        whenever(creditNotesService.getById(999)).thenReturn(odataDevolucao())
+
+        val devolucao = service.estornarPorDevolucao(adiantamento())
+
+        assertEquals(999, devolucao.docEntry)
+        verify(creditNotesService, never()).save(any())
+    }
+
+    private fun adiantamento(): DownPayment {
+        return DownPayment(
+            "C-001",
+            "2026-07-16",
+            listOf(Product("PIX-ITEM", "1", "82.00", 66)),
+            "3"
+        ).also {
+            it.docEntry = 321
+            it.docNum = "654"
+            it.docObjectCode = DocumentTypes.oDownPayments
+        }
+    }
+
+    private fun odataDevolucao(): OData {
+        return odata("""{"CardCode":"C-001","BPL_IDAssignedToInvoice":"3","DocEntry":999}""")
+    }
+
+    private fun odata(value: Any?): OData {
+        val backing = LinkedHashMap<String, Any?>()
+        backing["value"] = value
+        return OData(backing)
+    }
+}


### PR DESCRIPTION
Quando a uzzipay falhava, o adiantamento ja tinha sido salvo no SAP e ficava orfao sem dados de pix. A compensacao existente chamava adiantamentoService.cancel() (/Cancel), que nao existe para DownPayments no SAP - o estorno de adiantamento e sempre via devolucao (CreditNotes).

Agora o fluxo gera o pix primeiro; se a uzzipay falhar, nada e criado. Se falhar a gravacao do pix na parcela apos o adiantamento existir, o estorno usa DownPaymentService.estornarPorDevolucao (ja existente, idempotente), e se a propria devolucao falhar a mensagem orienta devolucao manual com o DocNum.