### PR TITLE
feat: PIX do contrato de venda futura com juros e permissão separada

### DIFF
--- a/src/main/kotlin/br/andrew/sap/controllers/documents/DownPaymentController.kt
+++ b/src/main/kotlin/br/andrew/sap/controllers/documents/DownPaymentController.kt
@@ -1,17 +1,24 @@
 package br.andrew.sap.controllers.documents
 
+import br.andrew.sap.model.authentication.User
 import br.andrew.sap.model.self.vendafutura.BoletoVf
 import br.andrew.sap.services.document.DownPaymentService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 
 @RestController
 @RequestMapping("down-payment")
-class DownPaymentController(val service : DownPaymentService) {
+class DownPaymentController(
+    val service : DownPaymentService,
+    @Value("\${pix.juros.mora.percent:0}") val jurosMoraPercent: Double
+) {
 
 
     @GetMapping("contrato-venda-futura/{id}")
@@ -20,7 +27,15 @@ class DownPaymentController(val service : DownPaymentService) {
     }
 
     @PostMapping("contrato-venda-futura/{id}/pix")
-    fun gerarPixByContrato(@PathVariable id : Int): List<BoletoVf> {
-        return service.createPixByContratoVendaFutura(id)
+    fun gerarPixByContrato(
+        @PathVariable id : Int,
+        @RequestParam("juros", defaultValue = "true") juros: Boolean = true,
+        auth : Authentication
+    ): List<BoletoVf> {
+        if(auth !is User)
+            throw Exception("Não foi possivel fazer a conversão de auth para User")
+        if(!auth.isAllCreatePix(juros))
+            throw Exception("Não é permitido criar pix!")
+        return service.createPixByContratoVendaFutura(id, if(juros) jurosMoraPercent else 0.0)
     }
 }

--- a/src/main/kotlin/br/andrew/sap/model/dto/PixGeradoResponse.kt
+++ b/src/main/kotlin/br/andrew/sap/model/dto/PixGeradoResponse.kt
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.annotation.JsonNaming
-import java.time.LocalDate
 
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -48,21 +47,8 @@ data class PixGeradoResponse(
         U_pix_due_date = installment.U_pix_consultar_ate,
         docEntry = installment.DocEntry,
         taxaJurosMoraPercent = taxaJurosMoraPercent,
-        jurosValor = calcularJuros(installment, taxaJurosMoraPercent),
+        jurosValor = installment.calcularJurosPix(taxaJurosMoraPercent),
         valorTitulo = installment.total,
-        valorTotal = installment.total + calcularJuros(installment, taxaJurosMoraPercent)
+        valorTotal = installment.total + installment.calcularJurosPix(taxaJurosMoraPercent)
     )
-
-    companion object {
-        private fun calcularJuros(installment: Installment, taxaJurosMoraPercent: Double): Double {
-            if (taxaJurosMoraPercent <= 0.0) {
-                return 0.0
-            }
-            val dueDate = installment.dueDate ?: return 0.0
-            val dueDateLocal = LocalDate.parse(dueDate)
-            val now = LocalDate.now()
-            val dataReferencia = if (dueDateLocal.isBefore(now)) now.plusDays(1) else now
-            return installment.calcularJurosSimplesPorDia(taxaJurosMoraPercent, dataReferencia)
-        }
-    }
 }

--- a/src/main/kotlin/br/andrew/sap/model/sap/documents/base/Installment.kt
+++ b/src/main/kotlin/br/andrew/sap/model/sap/documents/base/Installment.kt
@@ -165,6 +165,22 @@ class Installment(
     }
 
     /**
+     * Juros de mora usado nos PIX: mesma regra de [RequestPixDueDateBuilder] para escolher a
+     * data de referencia. Titulo a vencer usa hoje (juros zero); titulo vencido usa hoje+1,
+     * porque o vencimento do QR Code tambem e empurrado para hoje+1.
+     */
+    fun calcularJurosPix(taxaJurosMoraPercent: Double): Double {
+        if(taxaJurosMoraPercent <= 0.0) {
+            return 0.0
+        }
+        val vencimento = dueDate ?: return 0.0
+        val vencimentoLocal = LocalDate.parse(vencimento)
+        val hoje = LocalDate.now()
+        val dataReferencia = if(vencimentoLocal.isBefore(hoje)) hoje.plusDays(1) else hoje
+        return calcularJurosSimplesPorDia(taxaJurosMoraPercent, dataReferencia)
+    }
+
+    /**
      * Validade digital do PIX derivada do [U_pix_due_date]: para data pura usa o fim do
      * dia no fuso do sistema; para datetime (com ou sem offset) converte para OffsetDateTime.
      * Usado como fallback quando [U_pix_consultar_ate] ainda nao foi gravado (registros legados).

--- a/src/main/kotlin/br/andrew/sap/model/self/vendafutura/BoletoVf.kt
+++ b/src/main/kotlin/br/andrew/sap/model/self/vendafutura/BoletoVf.kt
@@ -26,9 +26,18 @@ class BoletoVf {
     var U_pix_due_date : String? = null
     var U_pix_proxima_consulta_em : String? = null
     var U_pix_consultar_ate : String? = null
+    var TaxaJurosMoraPercent : Double = 0.0
+    var JurosValor : Double = 0.0
+    var ValorTitulo : Double = 0.0
+    var ValorTotal : Double = 0.0
 
     companion object {
-        fun from(document: Document, installment: Installment? = null, devolucao: String? = null): BoletoVf {
+        fun from(
+            document: Document,
+            installment: Installment? = null,
+            devolucao: String? = null,
+            jurosMoraPercent: Double = 0.0
+        ): BoletoVf {
             return BoletoVf().also {
                 it.DocEntry = document.docEntry
                 it.DocNum = document.docNum
@@ -49,6 +58,17 @@ class BoletoVf {
                 it.U_pix_due_date = installment?.U_pix_consultar_ate
                 it.U_pix_proxima_consulta_em = installment?.U_pix_proxima_consulta_em
                 it.U_pix_consultar_ate = installment?.U_pix_consultar_ate
+                // O juros nao e gravado no SAP: so existe no valor do QR Code gerado na UzziPay.
+                // Por isso o detalhamento so vem preenchido na resposta da geracao, quando a taxa
+                // aplicada e conhecida. Num GET posterior a taxa e 0.0 e o breakdown fica zerado.
+                val juros = installment?.calcularJurosPix(jurosMoraPercent) ?: 0.0
+                val valorTitulo = installment?.total
+                    ?: document.DocTotal?.toDoubleOrNull()
+                    ?: 0.0
+                it.TaxaJurosMoraPercent = jurosMoraPercent
+                it.JurosValor = juros
+                it.ValorTitulo = valorTitulo
+                it.ValorTotal = valorTitulo + juros
             }
         }
     }

--- a/src/main/kotlin/br/andrew/sap/model/uzzipay/builder/RequestPixDueDateBuilder.kt
+++ b/src/main/kotlin/br/andrew/sap/model/uzzipay/builder/RequestPixDueDateBuilder.kt
@@ -30,10 +30,7 @@ class RequestPixDueDateBuilder(
             val dueDateLocal = LocalDate.parse(dueDate)
             val now = LocalDate.now()
             val effectiveDueDate = if (dueDateLocal.isBefore(now)) now.plusDays(1) else dueDateLocal
-            val dataReferencia = if (dueDateLocal.isBefore(now)) effectiveDueDate else now
-            val juros = if(jurosMoraPercent > 0.0)
-                it.calcularJurosSimplesPorDia(jurosMoraPercent, dataReferencia)
-            else 0.0
+            val juros = it.calcularJurosPix(jurosMoraPercent)
             RequestPixDueDate(
                 it.createExternalIdentifier(document),
                 conta,

--- a/src/main/kotlin/br/andrew/sap/services/document/DownPaymentService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/document/DownPaymentService.kt
@@ -127,7 +127,7 @@ class DownPaymentService(env: SapEnvrioment,
         return get(filter,orderBy).tryGetValues()
     }
 
-    fun getByContratoVendaFuturaStatus(id: Int): List<BoletoVf> {
+    fun getByContratoVendaFuturaStatus(id: Int, jurosMoraPercent: Double = 0.0): List<BoletoVf> {
         val parametros = listOf(Parameter("idVendaFutura",id),)
         val statusSql = sqlQueriesService.execute("boletos-status.sql",parametros)
             ?.tryGetValues<BoletoVf>()
@@ -144,9 +144,9 @@ class DownPaymentService(env: SapEnvrioment,
                 val devolucao = devolucaoPorDocNum[downPayment.docNum]
                 val installments = downPayment.documentInstallments.orEmpty()
                 if(installments.isEmpty()) {
-                    listOf(BoletoVf.from(downPayment, devolucao = devolucao))
+                    listOf(BoletoVf.from(downPayment, devolucao = devolucao, jurosMoraPercent = jurosMoraPercent))
                 } else {
-                    installments.map { BoletoVf.from(downPayment, it, devolucao) }
+                    installments.map { BoletoVf.from(downPayment, it, devolucao, jurosMoraPercent) }
                 }
             }
     }
@@ -176,7 +176,7 @@ class DownPaymentService(env: SapEnvrioment,
             .distinct()
     }
 
-    fun createPixByContratoVendaFutura(id: Int): List<BoletoVf> {
+    fun createPixByContratoVendaFutura(id: Int, jurosMoraPercent: Double = 0.0): List<BoletoVf> {
         getByContratoVendaFutura(id)
             .filter {
                 it.DocumentStatus == DocumentStatus.bost_Open &&
@@ -186,9 +186,9 @@ class DownPaymentService(env: SapEnvrioment,
                 val docEntry = document.docEntry
                     ?: throw Exception("Adiantamento do contrato $id sem DocEntry")
                 val downPayment = getById(docEntry).tryGetValue<DownPayment>()
-                createPix(downPayment)
+                createPix(downPayment, listOf(), jurosMoraPercent)
             }
-        return getByContratoVendaFuturaStatus(id)
+        return getByContratoVendaFuturaStatus(id, jurosMoraPercent)
     }
 
     fun createPix(

--- a/src/main/resources/application.properties.sample
+++ b/src/main/resources/application.properties.sample
@@ -14,6 +14,9 @@ uzzipay.contas[0].tokenJwt=jwt
 pix.schedule.enable=false
 pix.schedule.delay-minutes=5
 pix.schedule.consulta-interval-minutes=5
+# Taxa de mora do PIX em % AO DIA, multiplicada pelos dias de atraso. 0.1 = 3% ao mes (pro rata die); 0 = sem juros.
+# Vale para o PIX de titulo (contas a receber) e para o PIX dos boletos de contrato de venda futura.
+pix.juros.mora.percent=0.1
 
 # ----- Autenticacao via Keycloak (toggle) -----
 # Quando habilitado, o backend passa a aceitar tokens do Keycloak (RS256, via

--- a/src/test/kotlin/br/andrew/sap/controllers/documents/DownPaymentControllerTest.kt
+++ b/src/test/kotlin/br/andrew/sap/controllers/documents/DownPaymentControllerTest.kt
@@ -1,0 +1,77 @@
+package br.andrew.sap.controllers.documents
+
+import br.andrew.sap.model.authentication.User
+import br.andrew.sap.model.authentication.UserOriginEnum
+import br.andrew.sap.services.document.DownPaymentService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.`when`
+
+/**
+ * O PIX dos boletos de contrato de venda futura segue a mesma regra do PIX de titulo
+ * (PixController.gerarChave): role `pix` gera somente com juros, `pix_admin` gera com ou sem.
+ */
+class DownPaymentControllerTest {
+
+    private val service = mock(DownPaymentService::class.java)
+    private val controller = DownPaymentController(service, TAXA)
+
+    @Test
+    fun `role pix gera com juros aplicando a taxa configurada`() {
+        `when`(service.createPixByContratoVendaFutura(10, TAXA)).thenReturn(listOf())
+
+        controller.gerarPixByContrato(10, true, user("pix"))
+
+        verify(service).createPixByContratoVendaFutura(10, TAXA)
+    }
+
+    @Test
+    fun `role pix nao pode gerar sem juros`() {
+        val erro = assertThrows(Exception::class.java) {
+            controller.gerarPixByContrato(10, false, user("pix"))
+        }
+
+        assertEquals("Não é permitido criar pix!", erro.message)
+    }
+
+    @Test
+    fun `role pix_admin gera sem juros zerando a taxa`() {
+        `when`(service.createPixByContratoVendaFutura(10, 0.0)).thenReturn(listOf())
+
+        controller.gerarPixByContrato(10, false, user("pix_admin"))
+
+        verify(service).createPixByContratoVendaFutura(10, 0.0)
+    }
+
+    @Test
+    fun `role pix_admin tambem gera com juros`() {
+        `when`(service.createPixByContratoVendaFutura(10, TAXA)).thenReturn(listOf())
+
+        controller.gerarPixByContrato(10, true, user("pix_admin"))
+
+        verify(service).createPixByContratoVendaFutura(10, TAXA)
+    }
+
+    @Test
+    fun `usuario sem role de pix nao gera nem com juros`() {
+        val erro = assertThrows(Exception::class.java) {
+            controller.gerarPixByContrato(10, true, user("vendedor"))
+        }
+
+        assertEquals("Não é permitido criar pix!", erro.message)
+    }
+
+    private fun user(vararg roles: String): User {
+        return User(
+            "windson", "windson", UserOriginEnum.EmployeesInfo, "", "", "",
+            listOf(), roles.toList()
+        )
+    }
+
+    companion object {
+        private const val TAXA = 0.1
+    }
+}

--- a/src/test/kotlin/br/andrew/sap/model/self/vendafutura/BoletoVfTest.kt
+++ b/src/test/kotlin/br/andrew/sap/model/self/vendafutura/BoletoVfTest.kt
@@ -3,7 +3,10 @@ package br.andrew.sap.model.self.vendafutura
 import br.andrew.sap.model.sap.documents.DocumentStatus
 import br.andrew.sap.model.sap.documents.base.Document
 import br.andrew.sap.model.sap.documents.base.Installment
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
 
@@ -37,5 +40,75 @@ class BoletoVfTest {
         // o DTO envia a validade digital (consultar_ate) no campo due_date consumido pelo front
         assertEquals("2026-06-20T23:59:59", boleto.U_pix_due_date)
         assertEquals("2026-06-20T23:59:59", boleto.U_pix_consultar_ate)
+    }
+
+    @Test
+    fun `sem taxa informada nao detalha juros e valor total e o nominal`() {
+        val installment = Installment(LocalDate.now().minusDays(10), 1000.0).also { it.InstallmentId = 1 }
+        val downPayment = adiantamento()
+
+        val boleto = BoletoVf.from(downPayment, installment)
+
+        assertEquals(0.0, boleto.TaxaJurosMoraPercent)
+        assertEquals(0.0, boleto.JurosValor)
+        assertEquals(1000.0, boleto.ValorTitulo)
+        assertEquals(1000.0, boleto.ValorTotal)
+    }
+
+    @Test
+    fun `parcela vencida com taxa detalha juros e soma no valor total`() {
+        // vencida ha 10 dias: a data de referencia do PIX e hoje+1, entao sao 11 dias de mora
+        val installment = Installment(LocalDate.now().minusDays(10), 1000.0).also { it.InstallmentId = 1 }
+        val downPayment = adiantamento()
+
+        val boleto = BoletoVf.from(downPayment, installment, jurosMoraPercent = 0.1)
+
+        assertEquals(0.1, boleto.TaxaJurosMoraPercent)
+        assertEquals(11.0, boleto.JurosValor)
+        assertEquals(1000.0, boleto.ValorTitulo)
+        assertEquals(1011.0, boleto.ValorTotal)
+    }
+
+    @Test
+    fun `parcela a vencer nao tem juros mesmo com taxa configurada`() {
+        val installment = Installment(LocalDate.now().plusDays(5), 1000.0).also { it.InstallmentId = 1 }
+        val downPayment = adiantamento()
+
+        val boleto = BoletoVf.from(downPayment, installment, jurosMoraPercent = 0.1)
+
+        assertEquals(0.0, boleto.JurosValor)
+        assertEquals(1000.0, boleto.ValorTotal)
+    }
+
+    @Test
+    fun `adiantamento sem parcelas usa o DocTotal como valor do titulo`() {
+        val boleto = BoletoVf.from(adiantamento(), jurosMoraPercent = 0.1)
+
+        assertEquals(0.0, boleto.JurosValor)
+        assertEquals(1500.0, boleto.ValorTitulo)
+        assertEquals(1500.0, boleto.ValorTotal)
+    }
+
+    @Test
+    fun `o detalhamento de juros chega no json consumido pelo front`() {
+        // a classe usa @JsonInclude(NON_EMPTY): garante que os campos numericos nao sao suprimidos
+        val installment = Installment(LocalDate.now().minusDays(10), 1000.0).also { it.InstallmentId = 1 }
+        val boleto = BoletoVf.from(adiantamento(), installment, jurosMoraPercent = 0.1)
+
+        val json = ObjectMapper().registerKotlinModule().writeValueAsString(boleto)
+
+        assertTrue(json.contains("\"JurosValor\":11.0"), json)
+        assertTrue(json.contains("\"ValorTitulo\":1000.0"), json)
+        assertTrue(json.contains("\"ValorTotal\":1011.0"), json)
+        assertTrue(json.contains("\"TaxaJurosMoraPercent\":0.1"), json)
+    }
+
+    private fun adiantamento(): Document {
+        return Document("C1", LocalDate.now().toString(), listOf(), "2").also {
+            it.docEntry = 123
+            it.docNum = "456"
+            it.DocTotal = "1500.00"
+            it.DocumentStatus = DocumentStatus.bost_Open
+        }
     }
 }

--- a/src/test/kotlin/br/andrew/sap/services/document/DownPaymentServicePixContratoTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/document/DownPaymentServicePixContratoTest.kt
@@ -1,0 +1,122 @@
+package br.andrew.sap.services.document
+
+import br.andrew.sap.infrastructure.odata.OData
+import br.andrew.sap.model.enums.Cancelled
+import br.andrew.sap.model.envrioments.SapEnvrioment
+import br.andrew.sap.model.sap.documents.DocumentStatus
+import br.andrew.sap.model.sap.documents.DocumentTypes
+import br.andrew.sap.model.sap.documents.DownPayment
+import br.andrew.sap.model.sap.documents.base.Document
+import br.andrew.sap.model.sap.documents.base.Product
+import br.andrew.sap.services.AuthService
+import br.andrew.sap.services.BusinessPartnersService
+import br.andrew.sap.services.abstracts.SqlQueriesService
+import br.andrew.sap.services.bank.IncomingPaymentService
+import br.andrew.sap.services.bank.PaymentTermsTypesService
+import br.andrew.sap.services.batch.BatchService
+import br.andrew.sap.services.invent.BankPlusService
+import br.andrew.sap.services.journal.JournalEntriesService
+import br.andrew.sap.services.uzzipay.DynamicPixQrCodeService
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.whenever
+import org.springframework.web.client.RestTemplate
+
+/**
+ * A taxa de mora chega ao endpoint e precisa atravessar ate a geracao do QR Code — era
+ * exatamente esse repasse que faltava e fazia o contrato de venda futura sair sem juros.
+ */
+class DownPaymentServicePixContratoTest {
+
+    private val service = spy(
+        DownPaymentService(
+            mock(SapEnvrioment::class.java),
+            mock(SqlQueriesService::class.java),
+            mock(OrdersService::class.java),
+            mock(PaymentTermsTypesService::class.java),
+            mock(BankPlusService::class.java),
+            mock(AccountsReceivableService::class.java),
+            mock(IncomingPaymentService::class.java),
+            mock(CreditNotesService::class.java),
+            mock(BatchService::class.java),
+            mock(JournalEntriesService::class.java),
+            mock(DynamicPixQrCodeService::class.java),
+            mock(BusinessPartnersService::class.java),
+            "VF-ITEM",
+            66,
+            "none",
+            mock(RestTemplate::class.java),
+            mock(AuthService::class.java)
+        )
+    )
+
+    @Test
+    fun `repassa a taxa de mora para a geracao do pix e para a montagem dos boletos`() {
+        prepara()
+
+        service.createPixByContratoVendaFutura(10, 0.1)
+
+        verify(service).createPix(any(), eq(listOf()), eq(0.1))
+        verify(service).getByContratoVendaFuturaStatus(10, 0.1)
+    }
+
+    @Test
+    fun `sem taxa informada mantem o comportamento sem juros`() {
+        prepara()
+
+        service.createPixByContratoVendaFutura(10)
+
+        verify(service).createPix(any(), eq(listOf()), eq(0.0))
+        verify(service).getByContratoVendaFuturaStatus(10, 0.0)
+    }
+
+    @Test
+    fun `ignora adiantamento fechado ou cancelado`() {
+        val fechado = adiantamentoDoContrato().also { it.DocumentStatus = DocumentStatus.bost_Close }
+        val cancelado = adiantamentoDoContrato().also { it.Cancelled = Cancelled.tYES }
+        doReturn(listOf<Document>(fechado, cancelado)).whenever(service).getByContratoVendaFutura(eq(10), any())
+        doReturn(listOf<br.andrew.sap.model.self.vendafutura.BoletoVf>())
+            .whenever(service).getByContratoVendaFuturaStatus(eq(10), any())
+
+        service.createPixByContratoVendaFutura(10, 0.1)
+
+        verify(service, never()).createPix(any(), any(), any())
+    }
+
+    private fun prepara() {
+        doReturn(listOf<Document>(adiantamentoDoContrato()))
+            .whenever(service).getByContratoVendaFutura(eq(10), any())
+        doReturn(odataAdiantamento()).whenever(service).getById(321)
+        doReturn(listOf<br.andrew.sap.model.sap.documents.base.Installment>())
+            .whenever(service).createPix(any(), any(), any())
+        doReturn(listOf<br.andrew.sap.model.self.vendafutura.BoletoVf>())
+            .whenever(service).getByContratoVendaFuturaStatus(eq(10), any())
+    }
+
+    private fun adiantamentoDoContrato(): DownPayment {
+        return DownPayment(
+            "C-001",
+            "2026-07-16",
+            listOf(Product("VF-ITEM", "1", "1000.00", 66)),
+            "3"
+        ).also {
+            it.docEntry = 321
+            it.docNum = "654"
+            it.docObjectCode = DocumentTypes.oDownPayments
+            it.DocumentStatus = DocumentStatus.bost_Open
+            it.U_venda_futura = 10
+        }
+    }
+
+    private fun odataAdiantamento(): OData {
+        val backing = LinkedHashMap<String, Any?>()
+        backing["value"] = """{"CardCode":"C-001","BPL_IDAssignedToInvoice":"3","DocEntry":321}"""
+        return OData(backing)
+    }
+}


### PR DESCRIPTION
O PIX dos boletos de contrato saía sempre sem juros: createPixByContratoVendaFutura chamava createPix(downPayment) sem a taxa, caindo no default 0.0. Todo o resto do caminho já suportava juros — faltava só o repasse.

- DownPaymentController: ?juros= (default true) + isAllCreatePix, espelhando PixController.gerarChave. Role pix gera somente com juros; pix_admin dispensa.
- DownPaymentService: createPixByContratoVendaFutura e getByContratoVendaFuturaStatus repassam jurosMoraPercent.
- BoletoVf: expõe TaxaJurosMoraPercent, JurosValor, ValorTitulo e ValorTotal, como PixGeradoResponse já fazia.
- Installment.calcularJurosPix: o cálculo estava duplicado em PixGeradoResponse e reescrito de novo no RequestPixDueDateBuilder; os três passam a usar a mesma função, para o valor do QR Code e o breakdown exibido não divergirem.
- application.properties.sample: inclui pix.juros.mora.percent, que faltava.

isAllCreatePix foi mantido como está. Consequência operacional: usuários sem role pix/pix_admin passam a receber "Não é permitido criar pix!" no endpoint do contrato, onde antes bastava o rules.yml — as roles precisam ser atribuídas no ambiente (role.bind / Keycloak).