### PR TITLE
Cobrança: acompanhamento de títulos, dashboard e ações de cobrador

### DIFF
--- a/src/main/kotlin/br/andrew/sap/controllers/cobranca/CobrancaController.kt
+++ b/src/main/kotlin/br/andrew/sap/controllers/cobranca/CobrancaController.kt
@@ -111,9 +111,6 @@ class CobrancaController(
         return ResponseEntity.ok(service.registrarAcaoEmLote(itens, auth))
     }
 
-    // O dashboard vem em duas rotas de proposito: o resumo custa ~16 consultas ao SAP e a
-    // serie mensal custa mais uma paginada, entao separando a tela pinta em duas ondas em
-    // vez de esperar tudo pra mostrar o primeiro numero.
     @GetMapping("dashboard")
     fun dashboard(
         auth: Authentication,

--- a/src/main/kotlin/br/andrew/sap/controllers/cobranca/CobrancaController.kt
+++ b/src/main/kotlin/br/andrew/sap/controllers/cobranca/CobrancaController.kt
@@ -4,11 +4,14 @@ import br.andrew.sap.model.authentication.User
 import br.andrew.sap.model.cobranca.CobrancaAcaoLoteItem
 import br.andrew.sap.model.cobranca.CobrancaAcaoRequest
 import br.andrew.sap.model.cobranca.CobrancaAcaoResultado
+import br.andrew.sap.model.cobranca.CobrancaDashboard
 import br.andrew.sap.model.cobranca.CobrancaDominio
 import br.andrew.sap.model.cobranca.CobrancaHistorico
+import br.andrew.sap.model.cobranca.CobrancaMes
 import br.andrew.sap.model.cobranca.CobrancaRegistro
 import br.andrew.sap.model.cobranca.CobrancaTitulo
 import br.andrew.sap.services.cobranca.CobrancaConsultaService
+import br.andrew.sap.services.cobranca.CobrancaDashboardService
 import br.andrew.sap.services.cobranca.CobrancaDominioService
 import br.andrew.sap.services.cobranca.CobrancaService
 import org.springframework.http.ResponseEntity
@@ -28,6 +31,7 @@ class CobrancaController(
     val consultaService: CobrancaConsultaService,
     val service: CobrancaService,
     val dominioService: CobrancaDominioService,
+    val dashboardService: CobrancaDashboardService,
 ) {
 
     @GetMapping("titulos")
@@ -44,6 +48,8 @@ class CobrancaController(
         @RequestParam(required = false) situacaoSap: String?,
         @RequestParam(required = false) vencimentoDe: String?,
         @RequestParam(required = false) vencimentoAte: String?,
+        @RequestParam(required = false) semAcompanhamento: Boolean?,
+        @RequestParam(required = false) promessaVencidaAte: String?,
         @RequestParam(required = false) tipo: String?,
         @RequestParam(defaultValue = "0") pagina: Int,
         @RequestParam(defaultValue = "20") tamanho: Int,
@@ -64,6 +70,8 @@ class CobrancaController(
             situacaoSap = situacaoSap,
             vencimentoDe = vencimentoDe?.let { LocalDate.parse(it) },
             vencimentoAte = vencimentoAte?.let { LocalDate.parse(it) },
+            semAcompanhamento = semAcompanhamento,
+            promessaVencidaAte = promessaVencidaAte?.let { LocalDate.parse(it) },
             tipo = tipo,
             pagina = pagina,
             tamanhoPagina = tamanho,
@@ -101,6 +109,52 @@ class CobrancaController(
         if (auth !is User)
             return ResponseEntity.noContent().build()
         return ResponseEntity.ok(service.registrarAcaoEmLote(itens, auth))
+    }
+
+    // O dashboard vem em duas rotas de proposito: o resumo custa ~16 consultas ao SAP e a
+    // serie mensal custa mais uma paginada, entao separando a tela pinta em duas ondas em
+    // vez de esperar tudo pra mostrar o primeiro numero.
+    @GetMapping("dashboard")
+    fun dashboard(
+        auth: Authentication,
+        @RequestParam(required = false) filial: Int?,
+        @RequestParam(required = false) vendedor: Int?,
+        @RequestParam(required = false) de: String?,
+        @RequestParam(required = false) ate: String?,
+    ): ResponseEntity<CobrancaDashboard> {
+        if (auth !is User)
+            return ResponseEntity.noContent().build()
+        val hoje = LocalDate.now()
+        return ResponseEntity.ok(
+            dashboardService.resumo(
+                auth = auth,
+                filial = filial,
+                vendedor = vendedor,
+                de = de?.let { LocalDate.parse(it) } ?: hoje.withDayOfMonth(1),
+                ate = ate?.let { LocalDate.parse(it) } ?: hoje,
+                hoje = hoje,
+            )
+        )
+    }
+
+    @GetMapping("dashboard/evolucao")
+    fun evolucao(
+        auth: Authentication,
+        @RequestParam(required = false) filial: Int?,
+        @RequestParam(required = false) vendedor: Int?,
+        @RequestParam(defaultValue = "6") meses: Int,
+    ): ResponseEntity<List<CobrancaMes>> {
+        if (auth !is User)
+            return ResponseEntity.noContent().build()
+        return ResponseEntity.ok(
+            dashboardService.evolucao(
+                auth = auth,
+                filial = filial,
+                vendedor = vendedor,
+                meses = meses,
+                hoje = LocalDate.now(),
+            )
+        )
     }
 
     @GetMapping("dominios")

--- a/src/main/kotlin/br/andrew/sap/controllers/cobranca/CobrancaController.kt
+++ b/src/main/kotlin/br/andrew/sap/controllers/cobranca/CobrancaController.kt
@@ -1,0 +1,115 @@
+package br.andrew.sap.controllers.cobranca
+
+import br.andrew.sap.model.authentication.User
+import br.andrew.sap.model.cobranca.CobrancaAcaoLoteItem
+import br.andrew.sap.model.cobranca.CobrancaAcaoRequest
+import br.andrew.sap.model.cobranca.CobrancaAcaoResultado
+import br.andrew.sap.model.cobranca.CobrancaDominio
+import br.andrew.sap.model.cobranca.CobrancaHistorico
+import br.andrew.sap.model.cobranca.CobrancaRegistro
+import br.andrew.sap.model.cobranca.CobrancaTitulo
+import br.andrew.sap.services.cobranca.CobrancaConsultaService
+import br.andrew.sap.services.cobranca.CobrancaDominioService
+import br.andrew.sap.services.cobranca.CobrancaService
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("cobranca")
+class CobrancaController(
+    val consultaService: CobrancaConsultaService,
+    val service: CobrancaService,
+    val dominioService: CobrancaDominioService,
+) {
+
+    @GetMapping("titulos")
+    fun titulos(
+        auth: Authentication,
+        @RequestParam(required = false) filial: Int?,
+        @RequestParam(required = false) vendedor: Int?,
+        @RequestParam(required = false) cliente: String?,
+        @RequestParam(required = false) data: String?,
+        @RequestParam(required = false) diasAtrasoMin: Int?,
+        @RequestParam(required = false) status: String?,
+        @RequestParam(required = false) cobrador: String?,
+        @RequestParam(required = false) situacao: String?,
+        @RequestParam(required = false) situacaoSap: String?,
+        @RequestParam(required = false) vencimentoDe: String?,
+        @RequestParam(required = false) vencimentoAte: String?,
+        @RequestParam(required = false) tipo: String?,
+        @RequestParam(defaultValue = "0") pagina: Int,
+        @RequestParam(defaultValue = "20") tamanho: Int,
+    ): ResponseEntity<List<CobrancaTitulo>> {
+        if (auth !is User)
+            return ResponseEntity.noContent().build()
+
+        val resultado = consultaService.listar(
+            auth = auth,
+            filial = filial,
+            vendedor = vendedor,
+            cliente = cliente,
+            data = data?.let { LocalDate.parse(it) } ?: LocalDate.now(),
+            diasAtrasoMin = diasAtrasoMin,
+            status = status,
+            cobrador = cobrador,
+            situacao = situacao,
+            situacaoSap = situacaoSap,
+            vencimentoDe = vencimentoDe?.let { LocalDate.parse(it) },
+            vencimentoAte = vencimentoAte?.let { LocalDate.parse(it) },
+            tipo = tipo,
+            pagina = pagina,
+            tamanhoPagina = tamanho,
+        )
+        return ResponseEntity.ok(resultado)
+    }
+
+    @GetMapping("titulos/{tipo}/{docEntry}/{instlmntId}/historico")
+    fun historico(
+        @PathVariable tipo: String,
+        @PathVariable docEntry: Int,
+        @PathVariable instlmntId: Int,
+    ): List<CobrancaHistorico> {
+        return service.historico(tipo, docEntry, instlmntId)
+    }
+
+    @PostMapping("titulos/{tipo}/{docEntry}/{instlmntId}/acao")
+    fun registrarAcao(
+        @PathVariable tipo: String,
+        @PathVariable docEntry: Int,
+        @PathVariable instlmntId: Int,
+        @RequestBody req: CobrancaAcaoRequest,
+        auth: Authentication,
+    ): ResponseEntity<CobrancaRegistro> {
+        if (auth !is User)
+            return ResponseEntity.noContent().build()
+        return ResponseEntity.ok(service.registrarAcao(tipo, docEntry, instlmntId, req, auth))
+    }
+
+    @PostMapping("titulos/acoes")
+    fun registrarAcaoEmLote(
+        @RequestBody itens: List<CobrancaAcaoLoteItem>,
+        auth: Authentication,
+    ): ResponseEntity<List<CobrancaAcaoResultado>> {
+        if (auth !is User)
+            return ResponseEntity.noContent().build()
+        return ResponseEntity.ok(service.registrarAcaoEmLote(itens, auth))
+    }
+
+    @GetMapping("dominios")
+    fun dominios(@RequestParam(required = false) tipo: String?): List<CobrancaDominio> {
+        return dominioService.listar(tipo)
+    }
+
+    @PostMapping("dominios")
+    fun salvarDominio(@RequestBody dominio: CobrancaDominio): CobrancaDominio {
+        return dominioService.salvar(dominio)
+    }
+}

--- a/src/main/kotlin/br/andrew/sap/controllers/cobranca/CobrancaController.kt
+++ b/src/main/kotlin/br/andrew/sap/controllers/cobranca/CobrancaController.kt
@@ -84,8 +84,11 @@ class CobrancaController(
         @PathVariable tipo: String,
         @PathVariable docEntry: Int,
         @PathVariable instlmntId: Int,
-    ): List<CobrancaHistorico> {
-        return service.historico(tipo, docEntry, instlmntId)
+        auth: Authentication,
+    ): ResponseEntity<List<CobrancaHistorico>> {
+        if (auth !is User)
+            return ResponseEntity.noContent().build()
+        return ResponseEntity.ok(service.historico(auth, tipo, docEntry, instlmntId))
     }
 
     @PostMapping("titulos/{tipo}/{docEntry}/{instlmntId}/acao")

--- a/src/main/kotlin/br/andrew/sap/infrastructure/configurations/CacheConfig.kt
+++ b/src/main/kotlin/br/andrew/sap/infrastructure/configurations/CacheConfig.kt
@@ -64,6 +64,7 @@ class CacheConfigurationProperties(@Value("\${otp.ttl:300}") val otpTTL : Long) 
         cacheExpirations["produtos"] = timeoutSeconds
         cacheExpirations["unidade-grupo"] = timeoutSeconds
         cacheExpirations["employee-salesperson"] = timeoutSeconds
+        cacheExpirations["cobranca-dominio"] = timeoutSeconds
     }
 
     fun getCacheExpirations(): Map<String, Long> {

--- a/src/main/kotlin/br/andrew/sap/infrastructure/configurations/CacheConfig.kt
+++ b/src/main/kotlin/br/andrew/sap/infrastructure/configurations/CacheConfig.kt
@@ -65,6 +65,10 @@ class CacheConfigurationProperties(@Value("\${otp.ttl:300}") val otpTTL : Long) 
         cacheExpirations["unidade-grupo"] = timeoutSeconds
         cacheExpirations["employee-salesperson"] = timeoutSeconds
         cacheExpirations["cobranca-dominio"] = timeoutSeconds
+        // Nao usa timeoutSeconds (1h) de proposito: o cobrador registra uma acao e espera
+        // ver o numero mexer. 5 minutos ainda poupa as ~16 consultas que cada resumo faz
+        // no SAP, e o registrarAcao faz evict pra a mudanca aparecer na hora.
+        cacheExpirations["cobranca-dashboard"] = 5 * 60
     }
 
     fun getCacheExpirations(): Map<String, Long> {

--- a/src/main/kotlin/br/andrew/sap/infrastructure/create/udo/CobrancaConfiguration.kt
+++ b/src/main/kotlin/br/andrew/sap/infrastructure/create/udo/CobrancaConfiguration.kt
@@ -37,10 +37,6 @@ class CobrancaConfiguration(
         ).forEach { tableService.findOrCreate(it) }
 
         listOf(
-            // "NF" (fatura, OINV) ou "AD" (adiantamento, ODPI) - OBRIGATÓRIO na chave: o
-            // DocEntry de fatura e de adiantamento vêm de contadores independentes no SAP
-            // (ObjType 13 x 203), então sem esse campo uma fatura e um adiantamento com o
-            // mesmo DocEntry+Parcela colidiriam e sobrescreveriam um ao outro.
             FieldMd("Tipo", "Tipo (NF/AD)", "@COB_TITULO", DbType.db_Alpha),
             FieldMd("DocEntry", "Nº Doc.", "@COB_TITULO", DbType.db_Numeric),
             FieldMd("InstlmntID", "Nº Parcela", "@COB_TITULO", DbType.db_Numeric),
@@ -59,9 +55,6 @@ class CobrancaConfiguration(
 
         listOf(
             FieldMd("Data", "Data", "@COB_TITULO_L", DbType.db_Date),
-            // Tabela de linha (bott_MasterDataLines) nao ganha CreateDate/CreateTime do SAP
-            // como a master ganha - confirmado direto no banco (so tem LineId/Object/LogInst
-            // + os campos U_*). Sem um campo proprio pra hora, so da pra saber o dia da acao.
             FieldMd("Hora", "Hora", "@COB_TITULO_L", DbType.db_Alpha),
             FieldMd("Usuario", "Usuário", "@COB_TITULO_L", DbType.db_Alpha),
             FieldMd("Status", "Status", "@COB_TITULO_L", DbType.db_Alpha),
@@ -93,15 +86,8 @@ class CobrancaConfiguration(
         )
         udoService.findOrCreate(cobDominio)
 
-        // A key antiga ("ukCobTit") so tinha (DocEntry, InstlmntID) - sem o Tipo ela
-        // bloquearia uma fatura e um adiantamento genuinamente diferentes que calhem de
-        // ter o mesmo DocEntry+Parcela. O formato certo pra apagar essa key via Service
-        // Layer nao foi encontrado (nem TableName+KeyName nem KeyName sozinho funcionaram),
-        // entao ela fica para trás - se isso incomodar, remova manualmente pelo SAP B1
-        // (Ferramentas > Personalização > Chaves de Tabelas Definidas pelo Usuário).
         listOf(
             UserKeyMD(
-                // KeyName tem limite curto no SAP (visto em produção: 11 chars já é "Value too long")
                 "ukCobTit2", "@COB_TITULO", YesNo.tYES,
                 listOf(Elements("Tipo"), Elements("DocEntry"), Elements("InstlmntID"))
             ),

--- a/src/main/kotlin/br/andrew/sap/infrastructure/create/udo/CobrancaConfiguration.kt
+++ b/src/main/kotlin/br/andrew/sap/infrastructure/create/udo/CobrancaConfiguration.kt
@@ -1,0 +1,110 @@
+package br.andrew.sap.infrastructure.create.udo
+
+import br.andrew.sap.model.entity.ChildTables
+import br.andrew.sap.model.entity.DbType
+import br.andrew.sap.model.entity.Elements
+import br.andrew.sap.model.entity.FieldMd
+import br.andrew.sap.model.entity.LinkedSystemObject
+import br.andrew.sap.model.entity.UDOObjType
+import br.andrew.sap.model.entity.UserDefinedObject
+import br.andrew.sap.model.entity.UserKeyMD
+import br.andrew.sap.model.enums.YesNo
+import br.andrew.sap.model.sap.TableMd
+import br.andrew.sap.model.sap.TbType
+import br.andrew.sap.services.structs.UserFieldsMDService
+import br.andrew.sap.services.structs.UserKeyMDService
+import br.andrew.sap.services.structs.UserObjectsMDService
+import br.andrew.sap.services.structs.UserTablesMDService
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@Configuration
+@Profile("!test")
+@ConditionalOnProperty(value = ["fields.cobranca"], havingValue = "true", matchIfMissing = false)
+class CobrancaConfiguration(
+    val userFieldsMDService: UserFieldsMDService,
+    val udoService: UserObjectsMDService,
+    val userKeyService: UserKeyMDService,
+    val tableService: UserTablesMDService
+) {
+
+    init {
+        listOf(
+            TableMd("COB_TITULO", "Cobrança - Título", TbType.bott_MasterData),
+            TableMd("COB_TITULO_L", "Cobrança - Histórico", TbType.bott_MasterDataLines),
+            TableMd("COB_DOMINIO", "Cobrança - Domínio", TbType.bott_MasterData),
+        ).forEach { tableService.findOrCreate(it) }
+
+        listOf(
+            // "NF" (fatura, OINV) ou "AD" (adiantamento, ODPI) - OBRIGATÓRIO na chave: o
+            // DocEntry de fatura e de adiantamento vêm de contadores independentes no SAP
+            // (ObjType 13 x 203), então sem esse campo uma fatura e um adiantamento com o
+            // mesmo DocEntry+Parcela colidiriam e sobrescreveriam um ao outro.
+            FieldMd("Tipo", "Tipo (NF/AD)", "@COB_TITULO", DbType.db_Alpha),
+            FieldMd("DocEntry", "Nº Doc.", "@COB_TITULO", DbType.db_Numeric),
+            FieldMd("InstlmntID", "Nº Parcela", "@COB_TITULO", DbType.db_Numeric),
+            FieldMd("CardCode", "Cliente", "@COB_TITULO", DbType.db_Alpha).also {
+                it.LinkedSystemObject = LinkedSystemObject.ulBusinessPartners
+            },
+            FieldMd("Status", "Status", "@COB_TITULO", DbType.db_Alpha),
+            FieldMd("Acao", "Ação de Cobrança", "@COB_TITULO", DbType.db_Alpha),
+            FieldMd("Situacao", "Situação", "@COB_TITULO", DbType.db_Alpha),
+            FieldMd("Ocorrencia", "Ocorrência", "@COB_TITULO", DbType.db_Alpha),
+            FieldMd("Observacao", "Observação", "@COB_TITULO", DbType.db_Memo),
+            FieldMd("Cobrador", "Cobrador", "@COB_TITULO", DbType.db_Alpha),
+            FieldMd("DataAcao", "Data da Ação", "@COB_TITULO", DbType.db_Date),
+            FieldMd("DataPromessa", "Data Prometida", "@COB_TITULO", DbType.db_Date),
+        ).forEach { userFieldsMDService.findOrCreate(it) }
+
+        listOf(
+            FieldMd("Data", "Data", "@COB_TITULO_L", DbType.db_Date),
+            // Tabela de linha (bott_MasterDataLines) nao ganha CreateDate/CreateTime do SAP
+            // como a master ganha - confirmado direto no banco (so tem LineId/Object/LogInst
+            // + os campos U_*). Sem um campo proprio pra hora, so da pra saber o dia da acao.
+            FieldMd("Hora", "Hora", "@COB_TITULO_L", DbType.db_Alpha),
+            FieldMd("Usuario", "Usuário", "@COB_TITULO_L", DbType.db_Alpha),
+            FieldMd("Status", "Status", "@COB_TITULO_L", DbType.db_Alpha),
+            FieldMd("Acao", "Ação de Cobrança", "@COB_TITULO_L", DbType.db_Alpha),
+            FieldMd("Situacao", "Situação", "@COB_TITULO_L", DbType.db_Alpha),
+            FieldMd("Ocorrencia", "Ocorrência", "@COB_TITULO_L", DbType.db_Alpha),
+            FieldMd("Observacao", "Observação", "@COB_TITULO_L", DbType.db_Memo),
+            FieldMd("Cobrador", "Cobrador", "@COB_TITULO_L", DbType.db_Alpha),
+        ).forEach { userFieldsMDService.findOrCreate(it) }
+
+        listOf(
+            FieldMd("Tipo", "Tipo", "@COB_DOMINIO", DbType.db_Alpha),
+            FieldMd("Codigo", "Código", "@COB_DOMINIO", DbType.db_Alpha),
+            FieldMd("Descricao", "Descrição", "@COB_DOMINIO", DbType.db_Alpha),
+            FieldMd("Ordem", "Ordem", "@COB_DOMINIO", DbType.db_Numeric),
+            FieldMd("Ativo", "Ativo", "@COB_DOMINIO", DbType.db_Alpha).also {
+                it.defaultValue = "Y"
+            },
+        ).forEach { userFieldsMDService.findOrCreate(it) }
+
+        val cobTitulo = UserDefinedObject(
+            "COB_TITULO", "Cobrança - Título", "COB_TITULO", UDOObjType.boud_MasterData
+        )
+        cobTitulo.popChildTable(ChildTables("COB_TITULO_L"))
+        udoService.findOrCreate(cobTitulo)
+
+        val cobDominio = UserDefinedObject(
+            "COB_DOMINIO", "Cobrança - Domínio", "COB_DOMINIO", UDOObjType.boud_MasterData
+        )
+        udoService.findOrCreate(cobDominio)
+
+        // A key antiga ("ukCobTit") so tinha (DocEntry, InstlmntID) - sem o Tipo ela
+        // bloquearia uma fatura e um adiantamento genuinamente diferentes que calhem de
+        // ter o mesmo DocEntry+Parcela. O formato certo pra apagar essa key via Service
+        // Layer nao foi encontrado (nem TableName+KeyName nem KeyName sozinho funcionaram),
+        // entao ela fica para trás - se isso incomodar, remova manualmente pelo SAP B1
+        // (Ferramentas > Personalização > Chaves de Tabelas Definidas pelo Usuário).
+        listOf(
+            UserKeyMD(
+                // KeyName tem limite curto no SAP (visto em produção: 11 chars já é "Value too long")
+                "ukCobTit2", "@COB_TITULO", YesNo.tYES,
+                listOf(Elements("Tipo"), Elements("DocEntry"), Elements("InstlmntID"))
+            ),
+        ).forEach { userKeyService.findOrCreate(it) }
+    }
+}

--- a/src/main/kotlin/br/andrew/sap/infrastructure/create/udo/CobrancaDominioSeeder.kt
+++ b/src/main/kotlin/br/andrew/sap/infrastructure/create/udo/CobrancaDominioSeeder.kt
@@ -9,8 +9,6 @@ import org.springframework.context.annotation.Profile
 @Profile("!test")
 @ConditionalOnProperty(value = ["fields.cobranca"], havingValue = "true", matchIfMissing = false)
 class CobrancaDominioSeeder(
-    // dependência não usada diretamente: força o Spring a criar as UDTs/UDFs
-    // do CobrancaConfiguration antes de tentar semear dados nelas
     cobrancaConfiguration: CobrancaConfiguration,
     val service: CobrancaDominioService
 ) {

--- a/src/main/kotlin/br/andrew/sap/infrastructure/create/udo/CobrancaDominioSeeder.kt
+++ b/src/main/kotlin/br/andrew/sap/infrastructure/create/udo/CobrancaDominioSeeder.kt
@@ -1,0 +1,96 @@
+package br.andrew.sap.infrastructure.create.udo
+
+import br.andrew.sap.services.cobranca.CobrancaDominioService
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
+
+@Configuration
+@Profile("!test")
+@ConditionalOnProperty(value = ["fields.cobranca"], havingValue = "true", matchIfMissing = false)
+class CobrancaDominioSeeder(
+    // dependência não usada diretamente: força o Spring a criar as UDTs/UDFs
+    // do CobrancaConfiguration antes de tentar semear dados nelas
+    cobrancaConfiguration: CobrancaConfiguration,
+    val service: CobrancaDominioService
+) {
+
+    init {
+        val status = listOf(
+            "1" to "NÃO INICIADO",
+            "2" to "PRORROGADO",
+            "3" to "SEM CONTATO",
+            "4" to "PROBLEMA INTERNO (logística)",
+            "5" to "SEM SUCESSO COM O CLIENTE – Email Unidade",
+            "6" to "SLA UNIDADE (5 dias)",
+            "7" to "COMITE",
+            "8" to "EM NEGOCIAÇÃO",
+            "9" to "ACORDO ENVIADO",
+            "10" to "PAGO",
+            "11" to "PAGAMENTO ENTRE EMPRESAS",
+            "12" to "A VISTA",
+            "13" to "JURIDICO",
+        )
+
+        val acao = listOf(
+            "1" to "WATTS",
+            "2" to "PROCESSO INTERNO",
+            "3" to "EMAIL",
+            "4" to "LIGAÇÃO",
+            "5" to "PROTESTADO",
+            "6" to "SERASA",
+            "7" to "UNIDADE",
+        )
+
+        val situacao = listOf(
+            "1" to "PAGO",
+            "2" to "A RECEBER",
+            "3" to "DEVOLUÇÃO",
+            "4" to "RENEGOCIADO",
+            "5" to "JURIDICO",
+        )
+
+        val ocorrencia = listOf(
+            "1" to "VENDA A VISTA",
+            "2" to "COBRADO CLIENTE VIA WHATTSAPP, AGUARDANDO RETORNO",
+            "3" to "ENCONTRO DE CONTAS",
+            "4" to "COBRANÇA ENVIADA PARA O REPRESENTANTE",
+            "5" to "ACORDO DA DIRETORIA, JUNTO AO CLIENTE",
+            "6" to "CLIENTE NÃO RECONHECE A DIVIDA",
+            "7" to "SOLICITO CONTATO ATUALIZADO DO CLIENTE AO REPRESENTANTE",
+            "8" to "CLIENTE DISSE QUE ESTA ESPERANDO UM DINHEIRO PARA EFETUAR O PAGAMENTO",
+            "9" to "PAGAMENTO VIA DEPÓSITO EM CONTA",
+            "10" to "PAGAMENTO EM BEZERROS",
+            "11" to "COBRADO NOVAMENTE O CLIENTE, ATE O MOMENTO SEM RETORNO",
+            "12" to "FEITA RENEGOCIAÇÃO DA DIVIDA",
+            "13" to "PASSADO O VALOR ATUALIZADO, AGUARDANDO OK DO CLIENTE PARA RENEGOCIAR",
+            "14" to "PAGAMENTO AGENDANDO NO BANCO",
+            "15" to "LANÇAMENTO CONTABIL",
+            "16" to "PAGAMENTO ATE O FINAL DA SEMANA",
+            "17" to "ENVIADO BOLETO ATUALIZADO",
+            "18" to "ABATIMENTO EM COMISSÃO",
+            "19" to "NEGOCIADO PAGAMENTO NO CARTÃO",
+            "20" to "CLIENTE FICOU DE PAGAR NA UNIDADE",
+            "21" to "FEITO RENEGOCIAÇÃO(PRORROGAÇÃO DE VENCIMENTO)",
+            "22" to "PREVISÃO DE PAGAMENTO, PARA PROXIMA SEMANA.",
+            "23" to "TROCA DE PRODUTOS",
+            "24" to "DEBITO DO CLIENTE ENVIADO AO DEPARTAMENTO JURIDICO",
+            "25" to "DEBITO PROTESTADO, JUNTANDO DOCUMENTOS PARA ENVIO AO JURIDICO",
+            "26" to "ENVIADO VALOR PARA PAGAMENTO VIA PIX",
+            "27" to "TROCA DE PRODUTOS",
+            "28" to "DEBITO DO SECADOR",
+            "29" to "A VISTA PARA 30 DIAS",
+        )
+
+        seed("STATUS", status)
+        seed("ACAO", acao)
+        seed("SITUACAO", situacao)
+        seed("OCORRENCIA", ocorrencia)
+    }
+
+    private fun seed(tipo: String, valores: List<Pair<String, String>>) {
+        valores.forEachIndexed { index, (codigo, descricao) ->
+            service.findOrCreate(tipo, codigo, descricao, index + 1)
+        }
+    }
+}

--- a/src/main/kotlin/br/andrew/sap/infrastructure/create/udo/CobrancaDominioSeeder.kt
+++ b/src/main/kotlin/br/andrew/sap/infrastructure/create/udo/CobrancaDominioSeeder.kt
@@ -33,7 +33,7 @@ class CobrancaDominioSeeder(
         )
 
         val acao = listOf(
-            "1" to "WATTS",
+            "1" to "WhatsApp",
             "2" to "PROCESSO INTERNO",
             "3" to "EMAIL",
             "4" to "LIGAÇÃO",

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaAcao.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaAcao.kt
@@ -1,0 +1,34 @@
+package br.andrew.sap.model.cobranca
+
+class CobrancaAcaoRequest(
+    val status: String? = null,
+    val acao: String? = null,
+    val situacao: String? = null,
+    val ocorrencia: String? = null,
+    val observacao: String? = null,
+    val dataPromessa: String? = null,
+)
+
+class CobrancaAcaoLoteItem(
+    val tipo: String,
+    val docEntry: Int,
+    val instlmntId: Int,
+    val status: String? = null,
+    val acao: String? = null,
+    val situacao: String? = null,
+    val ocorrencia: String? = null,
+    val observacao: String? = null,
+    val dataPromessa: String? = null,
+) {
+    fun toAcaoRequest() = CobrancaAcaoRequest(status, acao, situacao, ocorrencia, observacao, dataPromessa)
+}
+
+class CobrancaAcaoResultado(
+    val tipo: String,
+    val docEntry: Int,
+    val instlmntId: Int,
+    val success: Boolean,
+    val error: String? = null,
+)
+
+class CobrancaException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaAdiantamentoSap.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaAdiantamentoSap.kt
@@ -1,0 +1,84 @@
+package br.andrew.sap.model.cobranca
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
+// Espelha 1:1 as colunas de cobranca-titulos-adiantamento.sql (ODPI/DPI6). O DocEntry do
+// adiantamento vem de um contador independente do DocEntry da fatura (ObjType 203 x 13) -
+// por isso o Tipo entra na chave da UDT (ver CobrancaConfiguration/CobrancaRegistro.code).
+// Sem COALESCE (sem precedente no parser do SQLQueries do SAP B1): o fallback do "NF" pro
+// numero do proprio adiantamento quando nao esta ligado a um contrato e feito aqui.
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class CobrancaAdiantamentoSap(
+    val DocEntry: Int,
+    val DocNumAdiantamento: Int,
+    val ContratoDocNum: Int?,
+    @get:JsonProperty("BPLId") val BPLId: Int,
+    @get:JsonProperty("BPLName") val BPLName: String?,
+    val CardCode: String,
+    val CardName: String,
+    val DocDate: String?,
+    val DocTotal: BigDecimal,
+    val SlpCode: Int?,
+    val SlpName: String?,
+    val InstlmntID: Int,
+    val InsTotal: BigDecimal,
+    val PaidToDate: BigDecimal,
+    val DueDate: String,
+    val StatusParcela: String,
+    val U_Status: String?,
+    val U_Cobrador: String?,
+    val U_Acao: String?,
+    val U_Situacao: String?,
+    val U_Ocorrencia: String?,
+    val U_Observacao: String?,
+    val U_DataAcao: String?,
+    val U_DataPromessa: String?,
+) {
+    fun toDto(hoje: LocalDate = LocalDate.now()): CobrancaTitulo {
+        val saldo = InsTotal.subtract(PaidToDate)
+        val diasAtraso = ChronoUnit.DAYS.between(LocalDate.parse(DueDate, DateTimeFormatter.BASIC_ISO_DATE), hoje)
+        // Ver comentario equivalente em CobrancaTituloSap.toDto - situacao vem do status da
+        // parcela no SAP, nao do saldo calculado.
+        val situacaoSap = if (StatusParcela == "O") "ABERTO" else "PAGO"
+        return CobrancaTitulo(
+            Tipo = CobrancaRegistro.TIPO_ADIANTAMENTO,
+            DocEntry = DocEntry,
+            DocNum = ContratoDocNum ?: DocNumAdiantamento,
+            Serial = null,
+            Series = null,
+            BPLId = BPLId,
+            BPLName = BPLName,
+            CardCode = CardCode,
+            CardName = CardName,
+            DocDate = DocDate,
+            DocTotal = DocTotal,
+            SlpCode = SlpCode,
+            SlpName = SlpName,
+            InstlmntID = InstlmntID,
+            InsTotal = InsTotal,
+            PaidToDate = PaidToDate,
+            DueDate = DueDate,
+            Saldo = saldo,
+            DiasAtraso = diasAtraso,
+            SituacaoSap = situacaoSap,
+            U_Status = U_Status,
+            U_Cobrador = U_Cobrador,
+            U_Acao = U_Acao,
+            U_Situacao = U_Situacao,
+            U_Ocorrencia = U_Ocorrencia,
+            U_Observacao = U_Observacao,
+            U_DataAcao = U_DataAcao,
+            U_DataPromessa = U_DataPromessa,
+        )
+    }
+}

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaAdiantamentoSap.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaAdiantamentoSap.kt
@@ -10,11 +10,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
-// Espelha 1:1 as colunas de cobranca-titulos-adiantamento.sql (ODPI/DPI6). O DocEntry do
-// adiantamento vem de um contador independente do DocEntry da fatura (ObjType 203 x 13) -
-// por isso o Tipo entra na chave da UDT (ver CobrancaConfiguration/CobrancaRegistro.code).
-// Sem COALESCE (sem precedente no parser do SQLQueries do SAP B1): o fallback do "NF" pro
-// numero do proprio adiantamento quando nao esta ligado a um contrato e feito aqui.
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -47,8 +42,6 @@ class CobrancaAdiantamentoSap(
     fun toDto(hoje: LocalDate = LocalDate.now()): CobrancaTitulo {
         val saldo = InsTotal.subtract(PaidToDate)
         val diasAtraso = ChronoUnit.DAYS.between(LocalDate.parse(DueDate, DateTimeFormatter.BASIC_ISO_DATE), hoje)
-        // Ver comentario equivalente em CobrancaTituloSap.toDto - situacao vem do status da
-        // parcela no SAP, nao do saldo calculado.
         val situacaoSap = if (StatusParcela == "O") "ABERTO" else "PAGO"
         return CobrancaTitulo(
             Tipo = CobrancaRegistro.TIPO_ADIANTAMENTO,

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaAgregadoSap.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaAgregadoSap.kt
@@ -53,8 +53,7 @@ class CobrancaTrabalhadosSap(
 class CobrancaRecuperadoDiaSap(
     val DocDate: String,
     val Recuperado: BigDecimal? = null,
-    val Documentos: Int? = null,
+    val DocEntry: Int,
 ) {
     fun recuperado(): BigDecimal = Recuperado ?: BigDecimal.ZERO
-    fun documentos(): Int = Documentos ?: 0
 }

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaAgregadoSap.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaAgregadoSap.kt
@@ -1,0 +1,83 @@
+package br.andrew.sap.model.cobranca
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import java.math.BigDecimal
+
+// Linha crua devolvida pelas views agregadas de carteira: cobranca-carteira.sql,
+// cobranca-sem-acao.sql e cobranca-promessa-vencida.sql (e os pares -adiantamento).
+// Uma classe so serve as tres porque as dimensoes que nao existem em cada view
+// simplesmente nao vem no JSON e ficam nulas (@JsonIgnoreProperties + campo nulavel).
+//
+// Total/Pago vem separados porque o saldo NAO e subtraido no SQL: sem IFNULL (que o
+// parser do SQLQueries nao aceita) um "PaidToDate" nulo envenenaria a soma inteira do
+// grupo. A subtracao acontece no saldo() aqui embaixo.
+//
+// A contagem e de PARCELA (count(P."InstlmntID"), uma linha do join = uma parcela), nao
+// de documento: a carteira e somada nas quatro faixas de aging, e uma nota com parcelas
+// em faixas diferentes seria contada uma vez em cada se a chave fosse o DocEntry. Parcela
+// tambem e a unidade que o time usa - as 213 linhas da planilha eram parcelas.
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class CobrancaAgregadoSap(
+    @get:JsonProperty("BPLId") val BPLId: Int?,
+    @get:JsonProperty("BPLName") val BPLName: String?,
+    val U_Status: String? = null,
+    val U_Cobrador: String? = null,
+    val Total: BigDecimal? = null,
+    val Pago: BigDecimal? = null,
+    val Parcelas: Int? = null,
+) {
+    fun saldo(): BigDecimal = (Total ?: BigDecimal.ZERO).subtract(Pago ?: BigDecimal.ZERO)
+    fun parcelas(): Int = Parcelas ?: 0
+}
+
+// Linha crua de cobranca-recuperado.sql / -adiantamento.sql. Aqui a contagem e por
+// DOCUMENTO distinto de propósito: recuperado nao e quebrado em faixas, entao nao ha soma
+// entre grupos pra duplicar, e "quantas notas voltaram" e o que o gestor pergunta.
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class CobrancaRecuperadoSap(
+    @get:JsonProperty("BPLId") val BPLId: Int?,
+    @get:JsonProperty("BPLName") val BPLName: String?,
+    val U_Cobrador: String? = null,
+    val Recuperado: BigDecimal? = null,
+    val Documentos: Int? = null,
+) {
+    fun recuperado(): BigDecimal = Recuperado ?: BigDecimal.ZERO
+    fun documentos(): Int = Documentos ?: 0
+}
+
+// Linha crua de cobranca-trabalhados.sql / -adiantamento.sql. Conta TITULOS distintos
+// tocados no periodo, nao acoes: cinco ligacoes no mesmo titulo nao e cinco vezes o
+// trabalho de cinco titulos, e count(DISTINCT ...) e a unica forma de count com
+// precedente nas views do projeto.
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class CobrancaTrabalhadosSap(
+    val U_Usuario: String? = null,
+    val Titulos: Int? = null,
+) {
+    fun titulos(): Int = Titulos ?: 0
+}
+
+// Linha crua de cobranca-recuperado-diario.sql / -adiantamento.sql. Agrupa por data
+// crua de pagamento (ORCT."DocDate") em vez de por mes porque nenhuma funcao de data
+// tem precedente nas views do projeto - o agrupamento por mes e feito em Kotlin.
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class CobrancaRecuperadoDiaSap(
+    val DocDate: String,
+    val Recuperado: BigDecimal? = null,
+    val Documentos: Int? = null,
+) {
+    fun recuperado(): BigDecimal = Recuperado ?: BigDecimal.ZERO
+    fun documentos(): Int = Documentos ?: 0
+}

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaAgregadoSap.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaAgregadoSap.kt
@@ -7,19 +7,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import java.math.BigDecimal
 
-// Linha crua devolvida pelas views agregadas de carteira: cobranca-carteira.sql,
-// cobranca-sem-acao.sql e cobranca-promessa-vencida.sql (e os pares -adiantamento).
-// Uma classe so serve as tres porque as dimensoes que nao existem em cada view
-// simplesmente nao vem no JSON e ficam nulas (@JsonIgnoreProperties + campo nulavel).
-//
-// Total/Pago vem separados porque o saldo NAO e subtraido no SQL: sem IFNULL (que o
-// parser do SQLQueries nao aceita) um "PaidToDate" nulo envenenaria a soma inteira do
-// grupo. A subtracao acontece no saldo() aqui embaixo.
-//
-// A contagem e de PARCELA (count(P."InstlmntID"), uma linha do join = uma parcela), nao
-// de documento: a carteira e somada nas quatro faixas de aging, e uma nota com parcelas
-// em faixas diferentes seria contada uma vez em cada se a chave fosse o DocEntry. Parcela
-// tambem e a unidade que o time usa - as 213 linhas da planilha eram parcelas.
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -36,9 +23,6 @@ class CobrancaAgregadoSap(
     fun parcelas(): Int = Parcelas ?: 0
 }
 
-// Linha crua de cobranca-recuperado.sql / -adiantamento.sql. Aqui a contagem e por
-// DOCUMENTO distinto de propósito: recuperado nao e quebrado em faixas, entao nao ha soma
-// entre grupos pra duplicar, e "quantas notas voltaram" e o que o gestor pergunta.
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -53,10 +37,6 @@ class CobrancaRecuperadoSap(
     fun documentos(): Int = Documentos ?: 0
 }
 
-// Linha crua de cobranca-trabalhados.sql / -adiantamento.sql. Conta TITULOS distintos
-// tocados no periodo, nao acoes: cinco ligacoes no mesmo titulo nao e cinco vezes o
-// trabalho de cinco titulos, e count(DISTINCT ...) e a unica forma de count com
-// precedente nas views do projeto.
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -67,9 +47,6 @@ class CobrancaTrabalhadosSap(
     fun titulos(): Int = Titulos ?: 0
 }
 
-// Linha crua de cobranca-recuperado-diario.sql / -adiantamento.sql. Agrupa por data
-// crua de pagamento (ORCT."DocDate") em vez de por mes porque nenhuma funcao de data
-// tem precedente nas views do projeto - o agrupamento por mes e feito em Kotlin.
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaDashboard.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaDashboard.kt
@@ -1,0 +1,126 @@
+package br.andrew.sap.model.cobranca
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import java.math.BigDecimal
+import java.time.LocalDate
+
+// Faixas de aging. NAO saem de CASE WHEN no SQL (o parser do SQLQueries do SAP nao
+// aceita) - cada faixa e uma janela de vencimento passada por parametro, e a conversao
+// mora aqui pra regra existir num lugar so.
+//
+// DiasAtraso = hoje - DueDate, logo:
+//   atraso >= diasMin  <=>  DueDate <= hoje - diasMin
+//   atraso <= diasMax  <=>  DueDate >= hoje - diasMax
+// E a mesma algebra que o diasAtrasoMin da consulta de titulos ja usa.
+// A primeira faixa comeca em 1 dia, nao em 0: parcela que vence HOJE nao esta em atraso, e a
+// tela de titulos ja usa diasAtrasoMin = 1 por padrao. Com 0 aqui, clicar na faixa "Até 30
+// dias" abriria uma lista com MENOS linhas do que o card mostra - o drill-down entregaria a
+// contradicao na cara do usuario.
+enum class FaixaAtraso(val rotulo: String, val diasMin: Int, val diasMax: Int?) {
+    ATE_30("Até 30 dias", 1, 30),
+    DE_31_A_60("31 a 60 dias", 31, 60),
+    DE_61_A_90("61 a 90 dias", 61, 90),
+    ACIMA_DE_90("Mais de 90 dias", 91, null);
+
+    fun vencimentoAte(hoje: LocalDate): LocalDate = hoje.minusDays(diasMin.toLong())
+
+    fun vencimentoDe(hoje: LocalDate): LocalDate =
+        diasMax?.let { hoje.minusDays(it.toLong()) } ?: LIMITE_INFERIOR
+
+    companion object {
+        // Sentinela larga em vez de omitir a comparacao: a view recebe sempre os dois
+        // parametros, entao a faixa aberta precisa de um piso que nao corte nada.
+        val LIMITE_INFERIOR: LocalDate = LocalDate.of(1900, 1, 1)
+    }
+}
+
+// DiasMin/DiasMax viajam junto do numero de proposito: sao eles que o drill-down usa pra
+// montar a janela de vencimento na tela de titulos. Se o front redefinisse as bordas por
+// conta propria, as duas definicoes divergiriam em silencio e o card mostraria um total
+// diferente da lista que ele abre.
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class CobrancaFaixa(
+    val Faixa: String,
+    val Saldo: BigDecimal,
+    val Parcelas: Int,
+    val DiasMin: Int,
+    val DiasMax: Int?,
+)
+
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class CobrancaPorFilial(
+    @get:JsonProperty("BPLId") val BPLId: Int?,
+    @get:JsonProperty("BPLName") val BPLName: String?,
+    val Saldo: BigDecimal,
+    val Parcelas: Int,
+)
+
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class CobrancaPorStatus(
+    val Status: String,
+    val Saldo: BigDecimal,
+    val Parcelas: Int,
+)
+
+// Uma linha por cobrador juntando esforco (TitulosTrabalhados) e resultado (Recuperado).
+// Sem o esforco nao da pra separar "trabalhou e nao recuperou" de "nao trabalhou", que e
+// exatamente o que a planilha nunca conseguiu responder.
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class CobrancaPorCobrador(
+    val Cobrador: String,
+    val Recuperado: BigDecimal,
+    val Documentos: Int,
+    val TitulosTrabalhados: Int,
+    val ParcelasComPromessaVencida: Int,
+)
+
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class CobrancaMes(
+    val Mes: String,
+    val Rotulo: String,
+    val Recuperado: BigDecimal,
+    val Documentos: Int,
+)
+
+// Resposta de GET /cobranca/dashboard. Carteira e sempre a foto de HOJE; Recuperado,
+// TitulosTrabalhados e as promessas sao do periodo pedido (De..Ate) - por isso as duas
+// datas voltam no corpo, pra tela poder rotular o card com o periodo certo em vez de
+// assumir "mes corrente".
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class CobrancaDashboard(
+    val De: String,
+    val Ate: String,
+    // Janela anterior de MESMA duracao, terminando um dia antes de De. Volta no corpo pra o
+    // card poder rotular "vs jul/26" em vez de um "vs anterior" que nao diz nada.
+    val DeAnterior: String,
+    val AteAnterior: String,
+    val CarteiraSaldo: BigDecimal,
+    val CarteiraParcelas: Int,
+    val Recuperado: BigDecimal,
+    val RecuperadoAnterior: BigDecimal,
+    val RecuperadoDocumentos: Int,
+    val SemAcaoSaldo: BigDecimal,
+    val SemAcaoParcelas: Int,
+    val PromessaVencidaSaldo: BigDecimal,
+    val PromessaVencidaParcelas: Int,
+    val Faixas: List<CobrancaFaixa>,
+    val PorFilial: List<CobrancaPorFilial>,
+    val PorStatus: List<CobrancaPorStatus>,
+    val PorCobrador: List<CobrancaPorCobrador>,
+)

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaDashboard.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaDashboard.kt
@@ -8,18 +8,6 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming
 import java.math.BigDecimal
 import java.time.LocalDate
 
-// Faixas de aging. NAO saem de CASE WHEN no SQL (o parser do SQLQueries do SAP nao
-// aceita) - cada faixa e uma janela de vencimento passada por parametro, e a conversao
-// mora aqui pra regra existir num lugar so.
-//
-// DiasAtraso = hoje - DueDate, logo:
-//   atraso >= diasMin  <=>  DueDate <= hoje - diasMin
-//   atraso <= diasMax  <=>  DueDate >= hoje - diasMax
-// E a mesma algebra que o diasAtrasoMin da consulta de titulos ja usa.
-// A primeira faixa comeca em 1 dia, nao em 0: parcela que vence HOJE nao esta em atraso, e a
-// tela de titulos ja usa diasAtrasoMin = 1 por padrao. Com 0 aqui, clicar na faixa "Até 30
-// dias" abriria uma lista com MENOS linhas do que o card mostra - o drill-down entregaria a
-// contradicao na cara do usuario.
 enum class FaixaAtraso(val rotulo: String, val diasMin: Int, val diasMax: Int?) {
     ATE_30("Até 30 dias", 1, 30),
     DE_31_A_60("31 a 60 dias", 31, 60),
@@ -32,16 +20,10 @@ enum class FaixaAtraso(val rotulo: String, val diasMin: Int, val diasMax: Int?) 
         diasMax?.let { hoje.minusDays(it.toLong()) } ?: LIMITE_INFERIOR
 
     companion object {
-        // Sentinela larga em vez de omitir a comparacao: a view recebe sempre os dois
-        // parametros, entao a faixa aberta precisa de um piso que nao corte nada.
         val LIMITE_INFERIOR: LocalDate = LocalDate.of(1900, 1, 1)
     }
 }
 
-// DiasMin/DiasMax viajam junto do numero de proposito: sao eles que o drill-down usa pra
-// montar a janela de vencimento na tela de titulos. Se o front redefinisse as bordas por
-// conta propria, as duas definicoes divergiriam em silencio e o card mostraria um total
-// diferente da lista que ele abre.
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -72,9 +54,6 @@ class CobrancaPorStatus(
     val Parcelas: Int,
 )
 
-// Uma linha por cobrador juntando esforco (TitulosTrabalhados) e resultado (Recuperado).
-// Sem o esforco nao da pra separar "trabalhou e nao recuperou" de "nao trabalhou", que e
-// exatamente o que a planilha nunca conseguiu responder.
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -96,18 +75,12 @@ class CobrancaMes(
     val Documentos: Int,
 )
 
-// Resposta de GET /cobranca/dashboard. Carteira e sempre a foto de HOJE; Recuperado,
-// TitulosTrabalhados e as promessas sao do periodo pedido (De..Ate) - por isso as duas
-// datas voltam no corpo, pra tela poder rotular o card com o periodo certo em vez de
-// assumir "mes corrente".
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
 class CobrancaDashboard(
     val De: String,
     val Ate: String,
-    // Janela anterior de MESMA duracao, terminando um dia antes de De. Volta no corpo pra o
-    // card poder rotular "vs jul/26" em vez de um "vs anterior" que nao diz nada.
     val DeAnterior: String,
     val AteAnterior: String,
     val CarteiraSaldo: BigDecimal,

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaDominio.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaDominio.kt
@@ -1,0 +1,27 @@
+package br.andrew.sap.model.cobranca
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class CobrancaDominio(
+    var Code: String? = null,
+    var U_Tipo: String? = null,
+    var U_Codigo: String? = null,
+    var U_Descricao: String? = null,
+    var U_Ordem: Int? = null,
+    var U_Ativo: String? = "Y"
+) {
+    companion object {
+        fun code(tipo: String, codigo: String) = "$tipo-$codigo"
+    }
+
+    @get:JsonIgnore
+    val rotulo: String
+        get() = "$U_Codigo - $U_Descricao"
+}

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaHistorico.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaHistorico.kt
@@ -17,9 +17,6 @@ class CobrancaHistorico(
     val U_Situacao: String? = null,
     val U_Ocorrencia: String? = null,
     val U_Observacao: String? = null,
-    // Linha (bott_MasterDataLines) nao ganha CreateDate/CreateTime do SAP como a
-    // master ganha - confirmado direto no banco. Por isso carimbamos a hora nós
-    // mesmos nesse campo, em vez de depender de um campo de sistema.
     val U_Hora: String? = null,
 ) {
     var LineId: Int? = null

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaHistorico.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaHistorico.kt
@@ -1,0 +1,26 @@
+package br.andrew.sap.model.cobranca
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class CobrancaHistorico(
+    val U_Data: String,
+    val U_Usuario: String,
+    val U_Cobrador: String,
+    val U_Status: String? = null,
+    val U_Acao: String? = null,
+    val U_Situacao: String? = null,
+    val U_Ocorrencia: String? = null,
+    val U_Observacao: String? = null,
+    // Linha (bott_MasterDataLines) nao ganha CreateDate/CreateTime do SAP como a
+    // master ganha - confirmado direto no banco. Por isso carimbamos a hora nós
+    // mesmos nesse campo, em vez de depender de um campo de sistema.
+    val U_Hora: String? = null,
+) {
+    var LineId: Int? = null
+}

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaRegistro.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaRegistro.kt
@@ -1,0 +1,35 @@
+package br.andrew.sap.model.cobranca
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class CobrancaRegistro(
+    var Code: String? = null,
+    var U_Tipo: String? = null,
+    var U_DocEntry: Int? = null,
+    var U_InstlmntID: Int? = null,
+    var U_CardCode: String? = null,
+    var U_Status: String? = null,
+    var U_Acao: String? = null,
+    var U_Situacao: String? = null,
+    var U_Ocorrencia: String? = null,
+    var U_Observacao: String? = null,
+    var U_Cobrador: String? = null,
+    var U_DataAcao: String? = null,
+    var U_DataPromessa: String? = null,
+    @JsonProperty("COB_TITULO_LCollection")
+    var historico: MutableList<CobrancaHistorico> = mutableListOf()
+) {
+    companion object {
+        const val TIPO_NOTA_FISCAL = "NF"
+        const val TIPO_ADIANTAMENTO = "AD"
+
+        fun code(tipo: String, docEntry: Int, instlmntId: Int) = "$tipo-$docEntry-$instlmntId"
+    }
+}

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaTitulo.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaTitulo.kt
@@ -1,0 +1,54 @@
+package br.andrew.sap.model.cobranca
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import java.math.BigDecimal
+
+// DTO de resposta ao front: os campos calculados (Saldo, DiasAtraso, SituacaoSap) ja
+// vem prontos daqui, calculados em Kotlin por CobrancaTituloSap.toDto() - a SQLQueries
+// do SAP so devolve as colunas cruas.
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class CobrancaTitulo(
+    val Tipo: String,
+    val DocEntry: Int,
+    val DocNum: Int,
+    val Serial: String?,
+    val Series: Int?,
+    // Sem @get:JsonProperty explícito, a serialização de saída (o JSON que vai pro front)
+    // vira "Bplid"/"Bplname" (o UpperCamelCaseStrategy mexe em nomes com 3+ maiúsculas
+    // seguidas no início) e o front, que espera "BPLId"/"BPLName", nunca acha o valor.
+    // "@JsonProperty" sem alvo explícito na property de um construtor Kotlin vai pro
+    // parâmetro (usado na leitura) e não pro getter (usado na escrita) - por isso o
+    // "@get:" é obrigatório aqui, não é só estilo.
+    @get:JsonProperty("BPLId") val BPLId: Int,
+    @get:JsonProperty("BPLName") val BPLName: String?,
+    val CardCode: String,
+    val CardName: String,
+    val DocDate: String?,
+    val DocTotal: BigDecimal,
+    val SlpCode: Int?,
+    val SlpName: String?,
+    val InstlmntID: Int,
+    val InsTotal: BigDecimal,
+    val PaidToDate: BigDecimal,
+    val DueDate: String,
+    val Saldo: BigDecimal,
+    val DiasAtraso: Long,
+    val SituacaoSap: String,
+    val U_Status: String?,
+    val U_Cobrador: String?,
+    val U_Acao: String?,
+    val U_Situacao: String?,
+    val U_Ocorrencia: String?,
+    val U_Observacao: String?,
+    val U_DataAcao: String?,
+    val U_DataPromessa: String?,
+) {
+    val code: String
+        get() = CobrancaRegistro.code(Tipo, DocEntry, InstlmntID)
+}

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaTitulo.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaTitulo.kt
@@ -7,9 +7,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import java.math.BigDecimal
 
-// DTO de resposta ao front: os campos calculados (Saldo, DiasAtraso, SituacaoSap) ja
-// vem prontos daqui, calculados em Kotlin por CobrancaTituloSap.toDto() - a SQLQueries
-// do SAP so devolve as colunas cruas.
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -19,12 +16,6 @@ class CobrancaTitulo(
     val DocNum: Int,
     val Serial: String?,
     val Series: Int?,
-    // Sem @get:JsonProperty explícito, a serialização de saída (o JSON que vai pro front)
-    // vira "Bplid"/"Bplname" (o UpperCamelCaseStrategy mexe em nomes com 3+ maiúsculas
-    // seguidas no início) e o front, que espera "BPLId"/"BPLName", nunca acha o valor.
-    // "@JsonProperty" sem alvo explícito na property de um construtor Kotlin vai pro
-    // parâmetro (usado na leitura) e não pro getter (usado na escrita) - por isso o
-    // "@get:" é obrigatório aqui, não é só estilo.
     @get:JsonProperty("BPLId") val BPLId: Int,
     @get:JsonProperty("BPLName") val BPLName: String?,
     val CardCode: String,

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaTituloSap.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaTituloSap.kt
@@ -1,0 +1,86 @@
+package br.andrew.sap.model.cobranca
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
+// Espelha 1:1 as colunas de cobranca-titulos.sql. O SQLQueries do SAP B1 usa um parser
+// proprio (mais limitado que o HANA puro) que nao reconhece IFNULL/DAYS_BETWEEN/CASE
+// WHEN nesse contexto - por isso os campos derivados (saldo, dias em atraso, situacao)
+// sao calculados aqui em Kotlin, do mesmo jeito que ParcelasAberto/Installment ja fazem.
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+class CobrancaTituloSap(
+    val DocEntry: Int,
+    val DocNum: Int,
+    val Serial: String?,
+    val Series: Int?,
+    @get:JsonProperty("BPLId") val BPLId: Int,
+    @get:JsonProperty("BPLName") val BPLName: String?,
+    val CardCode: String,
+    val CardName: String,
+    val DocDate: String?,
+    val DocTotal: BigDecimal,
+    val SlpCode: Int?,
+    val SlpName: String?,
+    val InstlmntID: Int,
+    val InsTotal: BigDecimal,
+    val PaidToDate: BigDecimal,
+    val DueDate: String,
+    val StatusParcela: String,
+    val U_Status: String?,
+    val U_Cobrador: String?,
+    val U_Acao: String?,
+    val U_Situacao: String?,
+    val U_Ocorrencia: String?,
+    val U_Observacao: String?,
+    val U_DataAcao: String?,
+    val U_DataPromessa: String?,
+) {
+    fun toDto(hoje: LocalDate = LocalDate.now()): CobrancaTitulo {
+        val saldo = InsTotal.subtract(PaidToDate)
+        val diasAtraso = ChronoUnit.DAYS.between(LocalDate.parse(DueDate, DateTimeFormatter.BASIC_ISO_DATE), hoje)
+        // Situacao vem do proprio status da parcela no SAP ('O' aberta / 'C' fechada), nao do
+        // saldo calculado (InsTotal - PaidToDate) - esse saldo pode dar negativo por rateio de
+        // moeda/adiantamento vinculado mesmo com a parcela ainda aberta no SAP, o que classificava
+        // titulo em aberto como "PAGO" errado.
+        val situacaoSap = if (StatusParcela == "O") "ABERTO" else "PAGO"
+        return CobrancaTitulo(
+            Tipo = CobrancaRegistro.TIPO_NOTA_FISCAL,
+            DocEntry = DocEntry,
+            DocNum = DocNum,
+            Serial = Serial,
+            Series = Series,
+            BPLId = BPLId,
+            BPLName = BPLName,
+            CardCode = CardCode,
+            CardName = CardName,
+            DocDate = DocDate,
+            DocTotal = DocTotal,
+            SlpCode = SlpCode,
+            SlpName = SlpName,
+            InstlmntID = InstlmntID,
+            InsTotal = InsTotal,
+            PaidToDate = PaidToDate,
+            DueDate = DueDate,
+            Saldo = saldo,
+            DiasAtraso = diasAtraso,
+            SituacaoSap = situacaoSap,
+            U_Status = U_Status,
+            U_Cobrador = U_Cobrador,
+            U_Acao = U_Acao,
+            U_Situacao = U_Situacao,
+            U_Ocorrencia = U_Ocorrencia,
+            U_Observacao = U_Observacao,
+            U_DataAcao = U_DataAcao,
+            U_DataPromessa = U_DataPromessa,
+        )
+    }
+}

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaTituloSap.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaTituloSap.kt
@@ -10,10 +10,6 @@ import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
-// Espelha 1:1 as colunas de cobranca-titulos.sql. O SQLQueries do SAP B1 usa um parser
-// proprio (mais limitado que o HANA puro) que nao reconhece IFNULL/DAYS_BETWEEN/CASE
-// WHEN nesse contexto - por isso os campos derivados (saldo, dias em atraso, situacao)
-// sao calculados aqui em Kotlin, do mesmo jeito que ParcelasAberto/Installment ja fazem.
 @JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
@@ -47,10 +43,6 @@ class CobrancaTituloSap(
     fun toDto(hoje: LocalDate = LocalDate.now()): CobrancaTitulo {
         val saldo = InsTotal.subtract(PaidToDate)
         val diasAtraso = ChronoUnit.DAYS.between(LocalDate.parse(DueDate, DateTimeFormatter.BASIC_ISO_DATE), hoje)
-        // Situacao vem do proprio status da parcela no SAP ('O' aberta / 'C' fechada), nao do
-        // saldo calculado (InsTotal - PaidToDate) - esse saldo pode dar negativo por rateio de
-        // moeda/adiantamento vinculado mesmo com a parcela ainda aberta no SAP, o que classificava
-        // titulo em aberto como "PAGO" errado.
         val situacaoSap = if (StatusParcela == "O") "ABERTO" else "PAGO"
         return CobrancaTitulo(
             Tipo = CobrancaRegistro.TIPO_NOTA_FISCAL,

--- a/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaTituloVendedorSap.kt
+++ b/src/main/kotlin/br/andrew/sap/model/cobranca/CobrancaTituloVendedorSap.kt
@@ -1,0 +1,11 @@
+package br.andrew.sap.model.cobranca
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+
+@JsonNaming(PropertyNamingStrategies.UpperCamelCaseStrategy::class)
+@JsonIgnoreProperties(ignoreUnknown = true)
+class CobrancaTituloVendedorSap(
+    val SlpCode: Int?,
+)

--- a/src/main/kotlin/br/andrew/sap/model/producao/Reprocessamento.kt
+++ b/src/main/kotlin/br/andrew/sap/model/producao/Reprocessamento.kt
@@ -44,7 +44,7 @@ class Reprocessamento(
     fun getReverseSaida(accountCode: String, valorTotal: Double) : EntradaSaidaEstoque {
         return EntradaSaidaEstoque(
             BPLId,
-            Produto(itemCode,quantidade,deposito,BigDecimal(valorTotal).divide(BigDecimal(quantidade)).toString())
+            Produto(itemCode,quantidade,deposito,BigDecimal(valorTotal).divide(BigDecimal(quantidade),4, RoundingMode.HALF_DOWN).toString())
                 .also {
                     it.BatchNumbers = lotes.map { BatchStock(it.BatchNumber,it.Quantity) }
                     it.AccountCode = accountCode

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaService.kt
@@ -94,13 +94,15 @@ class CobrancaConsultaService(val sqlQueriesService: SqlQueriesService) {
         return combinado.subList(inicio, fim)
     }
 
-    fun slpCodeDoTitulo(tipo: String, docEntry: Int): Int? {
+    fun buscarTituloParaEscopo(tipo: String, docEntry: Int, instlmntId: Int): CobrancaTituloVendedorSap? {
         val view = if (tipo == CobrancaRegistro.TIPO_ADIANTAMENTO)
             "cobranca-titulo-vendedor-adiantamento.sql"
         else
             "cobranca-titulo-vendedor.sql"
-        return sqlQueriesService.getAll<CobrancaTituloVendedorSap>(view, listOf(Parameter("docEntry", docEntry)))
-            .firstOrNull()?.SlpCode
+        return sqlQueriesService.getAll<CobrancaTituloVendedorSap>(
+            view,
+            listOf(Parameter("docEntry", docEntry), Parameter("instlmntId", instlmntId)),
+        ).firstOrNull()
     }
 
     private inline fun <reified T : Any> buscarAte(

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaService.kt
@@ -103,43 +103,57 @@ class CobrancaConsultaService(val sqlQueriesService: SqlQueriesService) {
             Parameter("promessaVencidaIsFilter", if (promessaVencidaAte == null) Int.MAX_VALUE else -1),
         )
 
-        // Adiantamentos (ODPI/DPI6): volume normalmente bem menor que o de faturas, entao
-        // busca tudo que casa com o filtro de uma vez. Se isso um dia crescer a ponto de
-        // ficar lento, aplicar aqui o mesmo "buscar so o suficiente" usado para as faturas.
-        val adiantamentos = if (tipo == CobrancaRegistro.TIPO_NOTA_FISCAL) emptyList() else
-            sqlQueriesService.getAll<CobrancaAdiantamentoSap>("cobranca-titulos-adiantamento.sql", parametros)
-                .map { it.toDto() }
-                .filter { passaNosFiltrosLocais(it, diasAtrasoMin, status, cobrador, situacao, situacaoSap, vencimentoDe, vencimentoAte) }
+        // As duas fontes buscam so o suficiente pra pagina pedida (ver buscarAte). Cortar as
+        // DUAS em (pagina+1)*tamanho continua devolvendo a pagina certa porque as duas views ja
+        // vem ordenadas por DueDate, DocNum: um titulo que caia dentro das N primeiras posicoes
+        // do merge nao pode estar depois da posicao N na sua propria lista - se estivesse,
+        // haveria N titulos menores que ele so ali dentro, e ele nao estaria entre os N
+        // primeiros do merge. No pior caso sobra linha pra pagina seguinte, que e recalculada
+        // do zero.
+        val alvo = (pagina + 1) * tamanhoPagina
 
-        // O SAP ja pagina a resposta do SQLQueries sozinho (nextLink). Sem filial/vendedor/
-        // cliente escolhidos isso e a empresa inteira - buscar tudo de uma vez (getAll) fazia
-        // dezenas de idas e voltas pro SAP remoto antes de responder, e a tela travava.
-        // Em vez disso, so busca paginas novas do SAP ate acumular linhas suficientes (depois
-        // dos filtros locais) pra cobrir a pagina pedida. Isso sempre basta mesmo somando os
-        // adiantamentos depois: as N faturas mais antigas buscadas aqui + TODOS os
-        // adiantamentos, ordenados e cortados na pagina certa, nunca deixam faltar fatura -
-        // no pior caso alguma sobra pra pagina seguinte, que e recalculada do zero.
-        val faturas = mutableListOf<CobrancaTitulo>()
-        if (tipo != CobrancaRegistro.TIPO_ADIANTAMENTO) {
-            val alvo = (pagina + 1) * tamanhoPagina
-            var paginaSap = sqlQueriesService.execute("cobranca-titulos.sql", parametros)
-
-            while (paginaSap != null) {
-                faturas.addAll(
-                    paginaSap.tryGetValues<CobrancaTituloSap>()
-                        .map { it.toDto() }
-                        .filter { passaNosFiltrosLocais(it, diasAtrasoMin, status, cobrador, situacao, situacaoSap, vencimentoDe, vencimentoAte) }
-                )
-                if (faturas.size >= alvo || !paginaSap.hasNext())
-                    break
-                paginaSap = sqlQueriesService.nextLink(paginaSap.nextLink())
+        val faturas = if (tipo == CobrancaRegistro.TIPO_ADIANTAMENTO) emptyList() else
+            buscarAte<CobrancaTituloSap>("cobranca-titulos.sql", parametros, alvo) { linhas ->
+                linhas.map { it.toDto() }
+                    .filter { passaNosFiltrosLocais(it, diasAtrasoMin, status, cobrador, situacao, situacaoSap, vencimentoDe, vencimentoAte) }
             }
-        }
+
+        // Adiantamentos (ODPI/DPI6) tem volume bem menor que o de faturas, mas ate aqui vinham
+        // de um getAll: varria a view inteira em TODA chamada, mesmo pra montar so as 20
+        // primeiras linhas. Custo fixo que crescia sozinho - a cada 20 adiantamentos novos em
+        // aberto, mais uma ida e volta ao SAP em toda carga da tela.
+        val adiantamentos = if (tipo == CobrancaRegistro.TIPO_NOTA_FISCAL) emptyList() else
+            buscarAte<CobrancaAdiantamentoSap>("cobranca-titulos-adiantamento.sql", parametros, alvo) { linhas ->
+                linhas.map { it.toDto() }
+                    .filter { passaNosFiltrosLocais(it, diasAtrasoMin, status, cobrador, situacao, situacaoSap, vencimentoDe, vencimentoAte) }
+            }
 
         val combinado = (faturas + adiantamentos).sortedWith(compareBy({ it.DueDate }, { it.DocNum }))
         val inicio = (pagina * tamanhoPagina).coerceAtMost(combinado.size)
         val fim = (inicio + tamanhoPagina).coerceAtMost(combinado.size)
         return combinado.subList(inicio, fim)
+    }
+
+    // O SAP ja pagina a resposta do SQLQueries sozinho (nextLink, 20 linhas por vez). Sem
+    // filial/vendedor/cliente escolhidos a view e a empresa inteira - varrer ate o fim fazia
+    // dezenas de idas e voltas pro SAP remoto antes de responder. Aqui so busca pagina nova
+    // enquanto faltar linha (ja depois do filtro local) pra cobrir a pagina pedida.
+    private inline fun <reified T : Any> buscarAte(
+        view: String,
+        parametros: List<Parameter>,
+        alvo: Int,
+        transformar: (List<T>) -> List<CobrancaTitulo>,
+    ): List<CobrancaTitulo> {
+        val acumulado = mutableListOf<CobrancaTitulo>()
+        var paginaSap = sqlQueriesService.execute(view, parametros)
+
+        while (paginaSap != null) {
+            acumulado.addAll(transformar(paginaSap.tryGetValues<T>()))
+            if (acumulado.size >= alvo || !paginaSap.hasNext())
+                break
+            paginaSap = sqlQueriesService.nextLink(paginaSap.nextLink())
+        }
+        return acumulado
     }
 
     // Todos esses filtros ja sao aplicados no SQL (ver a lista de Parameter acima) - isso aqui

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaService.kt
@@ -44,6 +44,10 @@ class CobrancaConsultaService(val sqlQueriesService: SqlQueriesService) {
         situacaoSap: String? = null,
         vencimentoDe: LocalDate? = null,
         vencimentoAte: LocalDate? = null,
+        // Vem do drill-down do dashboard: "sem nenhuma acao" = nunca teve registro em
+        // @COB_TITULO; promessaVencidaAte = tinha data prometida ate essa data e nao pagou.
+        semAcompanhamento: Boolean? = null,
+        promessaVencidaAte: LocalDate? = null,
         tipo: String? = null, // "NF", "AD" ou null (todos)
         pagina: Int = 0,
         tamanhoPagina: Int = 20,
@@ -89,6 +93,14 @@ class CobrancaConsultaService(val sqlQueriesService: SqlQueriesService) {
             Parameter("cobradorIsFilter", if (cobrador == null) Int.MAX_VALUE else -1),
             Parameter("situacao", situacao ?: SEM_FILTRO),
             Parameter("situacaoIsFilter", if (situacao == null) Int.MAX_VALUE else -1),
+            // Os dois filtros que o drill-down do dashboard usa. Diferente dos de cima, nao tem
+            // valor pra comparar - sao presenca/ausencia -, entao quem liga e desliga e so o
+            // IsFilter, no mesmo escape em coluna nao-nula.
+            Parameter("semAcompanhamentoIsFilter", if (semAcompanhamento == true) -1 else Int.MAX_VALUE),
+            // Quando o filtro esta desligado a data nao importa (o IsFilter larga a condicao
+            // inteira), mas o parametro tem que existir - a view sempre pede os dois.
+            Parameter("promessaVencidaAte", (promessaVencidaAte ?: data).toString()),
+            Parameter("promessaVencidaIsFilter", if (promessaVencidaAte == null) Int.MAX_VALUE else -1),
         )
 
         // Adiantamentos (ODPI/DPI6): volume normalmente bem menor que o de faturas, entao
@@ -135,6 +147,12 @@ class CobrancaConsultaService(val sqlQueriesService: SqlQueriesService) {
     // ao .sql do repositorio, o resultado continua correto, so mais lento. Nao adicione filtro
     // NOVO so aqui: filtro que existe apenas em Kotlin custa uma ida e volta ao SAP por linha
     // descartada, porque o laco de paginacao busca pagina nova ate juntar linha aprovada.
+    //
+    // semAcompanhamento e promessaVencidaAte NAO entram aqui de proposito. "Nunca teve
+    // acompanhamento" e a ausencia do registro em @COB_TITULO (C."Code" IS NULL), e o DTO nao
+    // carrega o Code - da pra chutar por "todos os U_* nulos", mas titulo que tem registro so
+    // com observacao preenchida seria classificado como sem acompanhamento e a rede DESCARTARIA
+    // linha que o SQL devolveu certo. Rede de seguranca imprecisa e pior que rede nenhuma.
     private fun passaNosFiltrosLocais(
         titulo: CobrancaTitulo,
         diasAtrasoMin: Int?,

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaService.kt
@@ -6,6 +6,7 @@ import br.andrew.sap.model.cobranca.CobrancaAdiantamentoSap
 import br.andrew.sap.model.cobranca.CobrancaRegistro
 import br.andrew.sap.model.cobranca.CobrancaTitulo
 import br.andrew.sap.model.cobranca.CobrancaTituloSap
+import br.andrew.sap.model.cobranca.CobrancaTituloVendedorSap
 import br.andrew.sap.services.abstracts.SqlQueriesService
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -45,7 +46,7 @@ class CobrancaConsultaService(val sqlQueriesService: SqlQueriesService) {
         pagina: Int = 0,
         tamanhoPagina: Int = 20,
     ): List<CobrancaTitulo> {
-        val vendedorEfetivo = if (auth.superVendedor() == Int.MAX_VALUE) vendedor else auth.getIdInt()
+        val vendedorEfetivo = CobrancaEscopo.vendedorEfetivo(auth, vendedor)
 
         val dataEfetiva = data.minusDays((diasAtrasoMin ?: 0).coerceAtLeast(0).toLong())
         val statusParcela = statusParcelaDe(situacaoSap)
@@ -91,6 +92,15 @@ class CobrancaConsultaService(val sqlQueriesService: SqlQueriesService) {
         val inicio = (pagina * tamanhoPagina).coerceAtMost(combinado.size)
         val fim = (inicio + tamanhoPagina).coerceAtMost(combinado.size)
         return combinado.subList(inicio, fim)
+    }
+
+    fun slpCodeDoTitulo(tipo: String, docEntry: Int): Int? {
+        val view = if (tipo == CobrancaRegistro.TIPO_ADIANTAMENTO)
+            "cobranca-titulo-vendedor-adiantamento.sql"
+        else
+            "cobranca-titulo-vendedor.sql"
+        return sqlQueriesService.getAll<CobrancaTituloVendedorSap>(view, listOf(Parameter("docEntry", docEntry)))
+            .firstOrNull()?.SlpCode
     }
 
     private inline fun <reified T : Any> buscarAte(

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaService.kt
@@ -14,17 +14,12 @@ import java.time.format.DateTimeFormatter
 @Service
 class CobrancaConsultaService(val sqlQueriesService: SqlQueriesService) {
 
-    private val formatoSap = DateTimeFormatter.BASIC_ISO_DATE // yyyyMMdd, igual ao que o SAP devolve em DueDate
+    private val formatoSap = DateTimeFormatter.BASIC_ISO_DATE
 
     companion object {
-        // Mesmo sentinela que o resto do projeto usa pra "filtro de texto desligado" (ver
-        // clienteIsFilter aqui e em contratos-vendafutura.sql): '~' e alto o suficiente na
-        // ordenacao pra que "coluna < '~'" seja verdadeiro pra qualquer valor real.
         private const val SEM_FILTRO = "~"
     }
 
-    // INV6/DPI6."Status" e 'O' (aberta) ou 'C' (fechada) - e a mesma fonte que alimenta o
-    // SituacaoSap em CobrancaTituloSap.toDto, por isso o de-para fica aqui e nao no controller.
     private fun statusParcelaDe(situacaoSap: String?): String = when (situacaoSap) {
         "ABERTO" -> "O"
         "PAGO" -> "C"
@@ -44,24 +39,14 @@ class CobrancaConsultaService(val sqlQueriesService: SqlQueriesService) {
         situacaoSap: String? = null,
         vencimentoDe: LocalDate? = null,
         vencimentoAte: LocalDate? = null,
-        // Vem do drill-down do dashboard: "sem nenhuma acao" = nunca teve registro em
-        // @COB_TITULO; promessaVencidaAte = tinha data prometida ate essa data e nao pagou.
         semAcompanhamento: Boolean? = null,
         promessaVencidaAte: LocalDate? = null,
-        tipo: String? = null, // "NF", "AD" ou null (todos)
+        tipo: String? = null,
         pagina: Int = 0,
         tamanhoPagina: Int = 20,
     ): List<CobrancaTitulo> {
         val vendedorEfetivo = if (auth.superVendedor() == Int.MAX_VALUE) vendedor else auth.getIdInt()
 
-        // Todo filtro que da pra resolver no SQL TEM que ser resolvido no SQL. O laco de
-        // paginacao abaixo so para quando junta linhas aprovadas suficientes, e o que sobra
-        // pro filtro local (passaNosFiltrosLocais) e descartado DEPOIS de ja ter vindo do SAP -
-        // ou seja, cada linha descartada localmente custa uma ida e volta HTTP a mais. Filtro
-        // seletivo resolvido so localmente fazia o backend varrer a inadimplencia inteira de 20
-        // em 20 pra montar uma pagina.
-        // DiasAtraso = hoje - DueDate, entao "atraso >= N" e o mesmo que "DueDate <= hoje - N":
-        // aproveita o :data que ja existe na view em vez de criar parametro novo.
         val dataEfetiva = data.minusDays((diasAtrasoMin ?: 0).coerceAtLeast(0).toLong())
         val statusParcela = statusParcelaDe(situacaoSap)
 
@@ -75,41 +60,19 @@ class CobrancaConsultaService(val sqlQueriesService: SqlQueriesService) {
             Parameter("clienteIsFilter", if (cliente == null) SEM_FILTRO else ""),
             Parameter("statusParcela", statusParcela),
             Parameter("statusParcelaIsFilter", if (statusParcela == SEM_FILTRO) SEM_FILTRO else ""),
-            // Data nao usa o idioma x/xIsFilter (feito pra igualdade) - com sentinela larga a
-            // comparacao de intervalo ja fica sempre verdadeira quando o filtro esta desligado.
             Parameter("vencimentoDe", vencimentoDe?.toString() ?: "1900-01-01"),
             Parameter("vencimentoAte", vencimentoAte?.toString() ?: "9999-12-31"),
-            // Status/Cobrador/Situacao vem do LEFT JOIN da UDT, entao sao NULOS pra titulo que
-            // nunca foi acompanhado - e o idioma normal (coluna < :xIsFilter) nao serve pra
-            // desligar o filtro num campo nulo, porque NULL < '~' e desconhecido e a linha
-            // sumiria. Por isso o "escape" quando o filtro esta desligado e testado numa coluna
-            // que NUNCA e nula (o DocEntry do proprio documento): DocEntry < Int.MAX_VALUE e
-            // verdadeiro pra toda linha, e a condicao inteira passa junto com os nulos. Com o
-            // filtro ligado vira DocEntry < -1 (falso), sobrando so a igualdade - e nulo nao e
-            // igual a nada, o que exclui os nao-acompanhados, que e exatamente o desejado.
             Parameter("status", status ?: SEM_FILTRO),
             Parameter("statusIsFilter", if (status == null) Int.MAX_VALUE else -1),
             Parameter("cobrador", cobrador ?: SEM_FILTRO),
             Parameter("cobradorIsFilter", if (cobrador == null) Int.MAX_VALUE else -1),
             Parameter("situacao", situacao ?: SEM_FILTRO),
             Parameter("situacaoIsFilter", if (situacao == null) Int.MAX_VALUE else -1),
-            // Os dois filtros que o drill-down do dashboard usa. Diferente dos de cima, nao tem
-            // valor pra comparar - sao presenca/ausencia -, entao quem liga e desliga e so o
-            // IsFilter, no mesmo escape em coluna nao-nula.
             Parameter("semAcompanhamentoIsFilter", if (semAcompanhamento == true) -1 else Int.MAX_VALUE),
-            // Quando o filtro esta desligado a data nao importa (o IsFilter larga a condicao
-            // inteira), mas o parametro tem que existir - a view sempre pede os dois.
             Parameter("promessaVencidaAte", (promessaVencidaAte ?: data).toString()),
             Parameter("promessaVencidaIsFilter", if (promessaVencidaAte == null) Int.MAX_VALUE else -1),
         )
 
-        // As duas fontes buscam so o suficiente pra pagina pedida (ver buscarAte). Cortar as
-        // DUAS em (pagina+1)*tamanho continua devolvendo a pagina certa porque as duas views ja
-        // vem ordenadas por DueDate, DocNum: um titulo que caia dentro das N primeiras posicoes
-        // do merge nao pode estar depois da posicao N na sua propria lista - se estivesse,
-        // haveria N titulos menores que ele so ali dentro, e ele nao estaria entre os N
-        // primeiros do merge. No pior caso sobra linha pra pagina seguinte, que e recalculada
-        // do zero.
         val alvo = (pagina + 1) * tamanhoPagina
 
         val faturas = if (tipo == CobrancaRegistro.TIPO_ADIANTAMENTO) emptyList() else
@@ -118,10 +81,6 @@ class CobrancaConsultaService(val sqlQueriesService: SqlQueriesService) {
                     .filter { passaNosFiltrosLocais(it, diasAtrasoMin, status, cobrador, situacao, situacaoSap, vencimentoDe, vencimentoAte) }
             }
 
-        // Adiantamentos (ODPI/DPI6) tem volume bem menor que o de faturas, mas ate aqui vinham
-        // de um getAll: varria a view inteira em TODA chamada, mesmo pra montar so as 20
-        // primeiras linhas. Custo fixo que crescia sozinho - a cada 20 adiantamentos novos em
-        // aberto, mais uma ida e volta ao SAP em toda carga da tela.
         val adiantamentos = if (tipo == CobrancaRegistro.TIPO_NOTA_FISCAL) emptyList() else
             buscarAte<CobrancaAdiantamentoSap>("cobranca-titulos-adiantamento.sql", parametros, alvo) { linhas ->
                 linhas.map { it.toDto() }
@@ -134,10 +93,6 @@ class CobrancaConsultaService(val sqlQueriesService: SqlQueriesService) {
         return combinado.subList(inicio, fim)
     }
 
-    // O SAP ja pagina a resposta do SQLQueries sozinho (nextLink, 20 linhas por vez). Sem
-    // filial/vendedor/cliente escolhidos a view e a empresa inteira - varrer ate o fim fazia
-    // dezenas de idas e voltas pro SAP remoto antes de responder. Aqui so busca pagina nova
-    // enquanto faltar linha (ja depois do filtro local) pra cobrir a pagina pedida.
     private inline fun <reified T : Any> buscarAte(
         view: String,
         parametros: List<Parameter>,
@@ -156,17 +111,6 @@ class CobrancaConsultaService(val sqlQueriesService: SqlQueriesService) {
         return acumulado
     }
 
-    // Todos esses filtros ja sao aplicados no SQL (ver a lista de Parameter acima) - isso aqui
-    // e rede de seguranca, nao a regra principal: se a view no SAP estiver defasada em relacao
-    // ao .sql do repositorio, o resultado continua correto, so mais lento. Nao adicione filtro
-    // NOVO so aqui: filtro que existe apenas em Kotlin custa uma ida e volta ao SAP por linha
-    // descartada, porque o laco de paginacao busca pagina nova ate juntar linha aprovada.
-    //
-    // semAcompanhamento e promessaVencidaAte NAO entram aqui de proposito. "Nunca teve
-    // acompanhamento" e a ausencia do registro em @COB_TITULO (C."Code" IS NULL), e o DTO nao
-    // carrega o Code - da pra chutar por "todos os U_* nulos", mas titulo que tem registro so
-    // com observacao preenchida seria classificado como sem acompanhamento e a rede DESCARTARIA
-    // linha que o SQL devolveu certo. Rede de seguranca imprecisa e pior que rede nenhuma.
     private fun passaNosFiltrosLocais(
         titulo: CobrancaTitulo,
         diasAtrasoMin: Int?,

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaService.kt
@@ -1,0 +1,156 @@
+package br.andrew.sap.services.cobranca
+
+import br.andrew.sap.infrastructure.odata.Parameter
+import br.andrew.sap.model.authentication.User
+import br.andrew.sap.model.cobranca.CobrancaAdiantamentoSap
+import br.andrew.sap.model.cobranca.CobrancaRegistro
+import br.andrew.sap.model.cobranca.CobrancaTitulo
+import br.andrew.sap.model.cobranca.CobrancaTituloSap
+import br.andrew.sap.services.abstracts.SqlQueriesService
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@Service
+class CobrancaConsultaService(val sqlQueriesService: SqlQueriesService) {
+
+    private val formatoSap = DateTimeFormatter.BASIC_ISO_DATE // yyyyMMdd, igual ao que o SAP devolve em DueDate
+
+    companion object {
+        // Mesmo sentinela que o resto do projeto usa pra "filtro de texto desligado" (ver
+        // clienteIsFilter aqui e em contratos-vendafutura.sql): '~' e alto o suficiente na
+        // ordenacao pra que "coluna < '~'" seja verdadeiro pra qualquer valor real.
+        private const val SEM_FILTRO = "~"
+    }
+
+    // INV6/DPI6."Status" e 'O' (aberta) ou 'C' (fechada) - e a mesma fonte que alimenta o
+    // SituacaoSap em CobrancaTituloSap.toDto, por isso o de-para fica aqui e nao no controller.
+    private fun statusParcelaDe(situacaoSap: String?): String = when (situacaoSap) {
+        "ABERTO" -> "O"
+        "PAGO" -> "C"
+        else -> SEM_FILTRO
+    }
+
+    fun listar(
+        auth: User,
+        filial: Int? = null,
+        vendedor: Int? = null,
+        cliente: String? = null,
+        data: LocalDate = LocalDate.now(),
+        diasAtrasoMin: Int? = null,
+        status: String? = null,
+        cobrador: String? = null,
+        situacao: String? = null,
+        situacaoSap: String? = null,
+        vencimentoDe: LocalDate? = null,
+        vencimentoAte: LocalDate? = null,
+        tipo: String? = null, // "NF", "AD" ou null (todos)
+        pagina: Int = 0,
+        tamanhoPagina: Int = 20,
+    ): List<CobrancaTitulo> {
+        val vendedorEfetivo = if (auth.superVendedor() == Int.MAX_VALUE) vendedor else auth.getIdInt()
+
+        // Todo filtro que da pra resolver no SQL TEM que ser resolvido no SQL. O laco de
+        // paginacao abaixo so para quando junta linhas aprovadas suficientes, e o que sobra
+        // pro filtro local (passaNosFiltrosLocais) e descartado DEPOIS de ja ter vindo do SAP -
+        // ou seja, cada linha descartada localmente custa uma ida e volta HTTP a mais. Filtro
+        // seletivo resolvido so localmente fazia o backend varrer a inadimplencia inteira de 20
+        // em 20 pra montar uma pagina.
+        // DiasAtraso = hoje - DueDate, entao "atraso >= N" e o mesmo que "DueDate <= hoje - N":
+        // aproveita o :data que ja existe na view em vez de criar parametro novo.
+        val dataEfetiva = data.minusDays((diasAtrasoMin ?: 0).coerceAtLeast(0).toLong())
+        val statusParcela = statusParcelaDe(situacaoSap)
+
+        val parametros = listOf(
+            Parameter("data", dataEfetiva.toString()),
+            Parameter("filial", filial ?: Int.MAX_VALUE),
+            Parameter("filialIsFilter", if (filial == null) Int.MAX_VALUE else -1),
+            Parameter("vendedor", vendedorEfetivo ?: Int.MAX_VALUE),
+            Parameter("vendedorIsFilter", if (vendedorEfetivo == null) Int.MAX_VALUE else -1),
+            Parameter("cliente", cliente ?: SEM_FILTRO),
+            Parameter("clienteIsFilter", if (cliente == null) SEM_FILTRO else ""),
+            Parameter("statusParcela", statusParcela),
+            Parameter("statusParcelaIsFilter", if (statusParcela == SEM_FILTRO) SEM_FILTRO else ""),
+            // Data nao usa o idioma x/xIsFilter (feito pra igualdade) - com sentinela larga a
+            // comparacao de intervalo ja fica sempre verdadeira quando o filtro esta desligado.
+            Parameter("vencimentoDe", vencimentoDe?.toString() ?: "1900-01-01"),
+            Parameter("vencimentoAte", vencimentoAte?.toString() ?: "9999-12-31"),
+            // Status/Cobrador/Situacao vem do LEFT JOIN da UDT, entao sao NULOS pra titulo que
+            // nunca foi acompanhado - e o idioma normal (coluna < :xIsFilter) nao serve pra
+            // desligar o filtro num campo nulo, porque NULL < '~' e desconhecido e a linha
+            // sumiria. Por isso o "escape" quando o filtro esta desligado e testado numa coluna
+            // que NUNCA e nula (o DocEntry do proprio documento): DocEntry < Int.MAX_VALUE e
+            // verdadeiro pra toda linha, e a condicao inteira passa junto com os nulos. Com o
+            // filtro ligado vira DocEntry < -1 (falso), sobrando so a igualdade - e nulo nao e
+            // igual a nada, o que exclui os nao-acompanhados, que e exatamente o desejado.
+            Parameter("status", status ?: SEM_FILTRO),
+            Parameter("statusIsFilter", if (status == null) Int.MAX_VALUE else -1),
+            Parameter("cobrador", cobrador ?: SEM_FILTRO),
+            Parameter("cobradorIsFilter", if (cobrador == null) Int.MAX_VALUE else -1),
+            Parameter("situacao", situacao ?: SEM_FILTRO),
+            Parameter("situacaoIsFilter", if (situacao == null) Int.MAX_VALUE else -1),
+        )
+
+        // Adiantamentos (ODPI/DPI6): volume normalmente bem menor que o de faturas, entao
+        // busca tudo que casa com o filtro de uma vez. Se isso um dia crescer a ponto de
+        // ficar lento, aplicar aqui o mesmo "buscar so o suficiente" usado para as faturas.
+        val adiantamentos = if (tipo == CobrancaRegistro.TIPO_NOTA_FISCAL) emptyList() else
+            sqlQueriesService.getAll<CobrancaAdiantamentoSap>("cobranca-titulos-adiantamento.sql", parametros)
+                .map { it.toDto() }
+                .filter { passaNosFiltrosLocais(it, diasAtrasoMin, status, cobrador, situacao, situacaoSap, vencimentoDe, vencimentoAte) }
+
+        // O SAP ja pagina a resposta do SQLQueries sozinho (nextLink). Sem filial/vendedor/
+        // cliente escolhidos isso e a empresa inteira - buscar tudo de uma vez (getAll) fazia
+        // dezenas de idas e voltas pro SAP remoto antes de responder, e a tela travava.
+        // Em vez disso, so busca paginas novas do SAP ate acumular linhas suficientes (depois
+        // dos filtros locais) pra cobrir a pagina pedida. Isso sempre basta mesmo somando os
+        // adiantamentos depois: as N faturas mais antigas buscadas aqui + TODOS os
+        // adiantamentos, ordenados e cortados na pagina certa, nunca deixam faltar fatura -
+        // no pior caso alguma sobra pra pagina seguinte, que e recalculada do zero.
+        val faturas = mutableListOf<CobrancaTitulo>()
+        if (tipo != CobrancaRegistro.TIPO_ADIANTAMENTO) {
+            val alvo = (pagina + 1) * tamanhoPagina
+            var paginaSap = sqlQueriesService.execute("cobranca-titulos.sql", parametros)
+
+            while (paginaSap != null) {
+                faturas.addAll(
+                    paginaSap.tryGetValues<CobrancaTituloSap>()
+                        .map { it.toDto() }
+                        .filter { passaNosFiltrosLocais(it, diasAtrasoMin, status, cobrador, situacao, situacaoSap, vencimentoDe, vencimentoAte) }
+                )
+                if (faturas.size >= alvo || !paginaSap.hasNext())
+                    break
+                paginaSap = sqlQueriesService.nextLink(paginaSap.nextLink())
+            }
+        }
+
+        val combinado = (faturas + adiantamentos).sortedWith(compareBy({ it.DueDate }, { it.DocNum }))
+        val inicio = (pagina * tamanhoPagina).coerceAtMost(combinado.size)
+        val fim = (inicio + tamanhoPagina).coerceAtMost(combinado.size)
+        return combinado.subList(inicio, fim)
+    }
+
+    // Todos esses filtros ja sao aplicados no SQL (ver a lista de Parameter acima) - isso aqui
+    // e rede de seguranca, nao a regra principal: se a view no SAP estiver defasada em relacao
+    // ao .sql do repositorio, o resultado continua correto, so mais lento. Nao adicione filtro
+    // NOVO so aqui: filtro que existe apenas em Kotlin custa uma ida e volta ao SAP por linha
+    // descartada, porque o laco de paginacao busca pagina nova ate juntar linha aprovada.
+    private fun passaNosFiltrosLocais(
+        titulo: CobrancaTitulo,
+        diasAtrasoMin: Int?,
+        status: String?,
+        cobrador: String?,
+        situacao: String?,
+        situacaoSap: String?,
+        vencimentoDe: LocalDate?,
+        vencimentoAte: LocalDate?,
+    ): Boolean {
+        return (diasAtrasoMin == null || titulo.DiasAtraso >= diasAtrasoMin) &&
+            (status == null || titulo.U_Status == status) &&
+            (cobrador == null || titulo.U_Cobrador == cobrador) &&
+            (situacao == null || titulo.U_Situacao == situacao) &&
+            (situacaoSap == null || titulo.SituacaoSap == situacaoSap) &&
+            (vencimentoDe == null || titulo.DueDate >= vencimentoDe.format(formatoSap)) &&
+            (vencimentoAte == null || titulo.DueDate <= vencimentoAte.format(formatoSap))
+    }
+}

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaDashboardService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaDashboardService.kt
@@ -150,7 +150,7 @@ class CobrancaDashboardService(val sqlQueriesService: SqlQueriesService) {
     }
 
     private fun escopo(auth: User, filial: Int?, vendedor: Int?): List<Parameter> {
-        val vendedorEfetivo = if (auth.superVendedor() == Int.MAX_VALUE) vendedor else auth.getIdInt()
+        val vendedorEfetivo = CobrancaEscopo.vendedorEfetivo(auth, vendedor)
         return listOf(
             Parameter("filial", filial ?: Int.MAX_VALUE),
             Parameter("filialIsFilter", if (filial == null) Int.MAX_VALUE else -1),

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaDashboardService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaDashboardService.kt
@@ -1,0 +1,256 @@
+package br.andrew.sap.services.cobranca
+
+import br.andrew.sap.infrastructure.odata.Parameter
+import br.andrew.sap.model.authentication.User
+import br.andrew.sap.model.cobranca.CobrancaAgregadoSap
+import br.andrew.sap.model.cobranca.CobrancaDashboard
+import br.andrew.sap.model.cobranca.CobrancaFaixa
+import br.andrew.sap.model.cobranca.CobrancaMes
+import br.andrew.sap.model.cobranca.CobrancaPorCobrador
+import br.andrew.sap.model.cobranca.CobrancaPorFilial
+import br.andrew.sap.model.cobranca.CobrancaPorStatus
+import br.andrew.sap.model.cobranca.CobrancaRecuperadoDiaSap
+import br.andrew.sap.model.cobranca.CobrancaRecuperadoSap
+import br.andrew.sap.model.cobranca.CobrancaTrabalhadosSap
+import br.andrew.sap.model.cobranca.FaixaAtraso
+import br.andrew.sap.services.abstracts.SqlQueriesService
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.YearMonth
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
+// Agregacoes do dashboard de cobranca. Diferente do CobrancaConsultaService, aqui nao
+// existe paginacao: cada view devolve poucas dezenas de linhas ja somadas pelo SAP.
+//
+// O preco disso e a quantidade de consultas - faixa de aging nao sai de CASE WHEN no
+// parser do SQLQueries, entao cada faixa e uma janela de vencimento separada, e cada
+// familia de numero tem par NF/adiantamento pra o total da carteira fechar com a tela
+// de titulos. Sao ~16 idas ao SAP por resumo(), e e por isso que o resultado e cacheado
+// (ver "cobranca-dashboard" em CacheConfig) e que a serie mensal mora num endpoint
+// proprio, pra tela pintar em duas ondas em vez de esperar tudo.
+@Service
+class CobrancaDashboardService(val sqlQueriesService: SqlQueriesService) {
+
+    companion object {
+        private const val SEM_ACOMPANHAMENTO = "Sem acompanhamento"
+        private const val SEM_COBRADOR = "Sem cobrador"
+        private val MESES = listOf(
+            "jan", "fev", "mar", "abr", "mai", "jun",
+            "jul", "ago", "set", "out", "nov", "dez",
+        )
+    }
+
+    // A chave inclui o usuario porque o escopo de vendedor e resolvido aqui dentro:
+    // sem isso a foto de um vendedor poderia ser servida pra outro.
+    @Cacheable(
+        "cobranca-dashboard",
+        key = "'resumo-' + #auth.getIdInt() + '-' + #filial + '-' + #vendedor + '-' + #de + '-' + #ate + '-' + #hoje",
+    )
+    fun resumo(
+        auth: User,
+        filial: Int? = null,
+        vendedor: Int? = null,
+        de: LocalDate,
+        ate: LocalDate,
+        hoje: LocalDate = LocalDate.now(),
+    ): CobrancaDashboard {
+        val escopo = escopo(auth, filial, vendedor)
+
+        val faixas = mutableListOf<CobrancaFaixa>()
+        val carteira = mutableListOf<CobrancaAgregadoSap>()
+        for (faixa in FaixaAtraso.values()) {
+            val linhas = carteiraDaFaixa(faixa, hoje, escopo)
+            carteira.addAll(linhas)
+            faixas.add(
+                CobrancaFaixa(
+                    Faixa = faixa.rotulo,
+                    Saldo = linhas.somaSaldo(),
+                    Parcelas = linhas.somaParcelas(),
+                    DiasMin = faixa.diasMin,
+                    DiasMax = faixa.diasMax,
+                )
+            )
+        }
+
+        val recuperado = buscarAgregado<CobrancaRecuperadoSap>(
+            "cobranca-recuperado.sql", "cobranca-recuperado-adiantamento.sql",
+            escopo + listOf(Parameter("de", de.toString()), Parameter("ate", ate.toString())),
+        )
+
+        // Janela anterior de mesma duracao pro delta do card. Reaproveita a mesma view (ela ja
+        // recebe :de/:ate), entao nao ha SQL novo - so duas consultas a mais, dentro do cache.
+        val diasDoPeriodo = ChronoUnit.DAYS.between(de, ate) + 1
+        val ateAnterior = de.minusDays(1)
+        val deAnterior = ateAnterior.minusDays(diasDoPeriodo - 1)
+        val recuperadoAnterior = buscarAgregado<CobrancaRecuperadoSap>(
+            "cobranca-recuperado.sql", "cobranca-recuperado-adiantamento.sql",
+            escopo + listOf(Parameter("de", deAnterior.toString()), Parameter("ate", ateAnterior.toString())),
+        )
+
+        val semAcao = buscarAgregado<CobrancaAgregadoSap>(
+            "cobranca-sem-acao.sql", "cobranca-sem-acao-adiantamento.sql",
+            escopo + listOf(Parameter("data", hoje.toString())),
+        )
+
+        val promessas = buscarAgregado<CobrancaAgregadoSap>(
+            "cobranca-promessa-vencida.sql", "cobranca-promessa-vencida-adiantamento.sql",
+            escopo + listOf(Parameter("data", hoje.toString())),
+        )
+
+        val trabalhados = buscarAgregado<CobrancaTrabalhadosSap>(
+            "cobranca-trabalhados.sql", "cobranca-trabalhados-adiantamento.sql",
+            escopo + listOf(Parameter("de", de.toString()), Parameter("ate", ate.toString())),
+        )
+
+        return CobrancaDashboard(
+            De = de.toString(),
+            Ate = ate.toString(),
+            DeAnterior = deAnterior.toString(),
+            AteAnterior = ateAnterior.toString(),
+            CarteiraSaldo = carteira.somaSaldo(),
+            CarteiraParcelas = carteira.somaParcelas(),
+            Recuperado = recuperado.fold(BigDecimal.ZERO) { acc, it -> acc.add(it.recuperado()) },
+            RecuperadoAnterior = recuperadoAnterior.fold(BigDecimal.ZERO) { acc, it -> acc.add(it.recuperado()) },
+            RecuperadoDocumentos = recuperado.sumOf { it.documentos() },
+            SemAcaoSaldo = semAcao.somaSaldo(),
+            SemAcaoParcelas = semAcao.somaParcelas(),
+            PromessaVencidaSaldo = promessas.somaSaldo(),
+            PromessaVencidaParcelas = promessas.somaParcelas(),
+            Faixas = faixas,
+            PorFilial = porFilial(carteira),
+            PorStatus = porStatus(carteira),
+            PorCobrador = porCobrador(recuperado, trabalhados, promessas),
+        )
+    }
+
+    @Cacheable(
+        "cobranca-dashboard",
+        key = "'evolucao-' + #auth.getIdInt() + '-' + #filial + '-' + #vendedor + '-' + #meses + '-' + #hoje",
+    )
+    fun evolucao(
+        auth: User,
+        filial: Int? = null,
+        vendedor: Int? = null,
+        meses: Int = 6,
+        hoje: LocalDate = LocalDate.now(),
+    ): List<CobrancaMes> {
+        val quantidade = meses.coerceIn(1, 24)
+        val primeiroMes = YearMonth.from(hoje).minusMonths((quantidade - 1).toLong())
+
+        // Uma consulta cobre a janela inteira: a view agrupa por data crua de pagamento
+        // e o mes e montado aqui, porque nenhuma funcao de data (MONTH, LEFT, TO_CHAR)
+        // tem precedente nas views do projeto.
+        val dias = buscarAgregado<CobrancaRecuperadoDiaSap>(
+            "cobranca-recuperado-diario.sql", "cobranca-recuperado-diario-adiantamento.sql",
+            escopo(auth, filial, vendedor) + listOf(
+                Parameter("de", primeiroMes.atDay(1).toString()),
+                Parameter("ate", hoje.toString()),
+            ),
+        )
+
+        val porMes = dias.groupBy { YearMonth.from(LocalDate.parse(it.DocDate, DateTimeFormatter.BASIC_ISO_DATE)) }
+
+        // Mes sem pagamento tem que aparecer como zero, nao desaparecer do grafico -
+        // buraco na serie faz o leitor achar que o mes nao foi medido.
+        return (0 until quantidade).map { indice ->
+            val mes = primeiroMes.plusMonths(indice.toLong())
+            val linhas = porMes[mes] ?: emptyList()
+            CobrancaMes(
+                Mes = mes.toString(),
+                Rotulo = "${MESES[mes.monthValue - 1]}/${mes.year % 100}",
+                Recuperado = linhas.fold(BigDecimal.ZERO) { acc, it -> acc.add(it.recuperado()) },
+                Documentos = linhas.sumOf { it.documentos() },
+            )
+        }
+    }
+
+    // Mesma regra da consulta de titulos (CobrancaConsultaService): quem nao e
+    // super-vendedor so ve a propria carteira, independente do que mandar no parametro.
+    private fun escopo(auth: User, filial: Int?, vendedor: Int?): List<Parameter> {
+        val vendedorEfetivo = if (auth.superVendedor() == Int.MAX_VALUE) vendedor else auth.getIdInt()
+        return listOf(
+            Parameter("filial", filial ?: Int.MAX_VALUE),
+            Parameter("filialIsFilter", if (filial == null) Int.MAX_VALUE else -1),
+            Parameter("vendedor", vendedorEfetivo ?: Int.MAX_VALUE),
+            Parameter("vendedorIsFilter", if (vendedorEfetivo == null) Int.MAX_VALUE else -1),
+        )
+    }
+
+    private fun carteiraDaFaixa(faixa: FaixaAtraso, hoje: LocalDate, escopo: List<Parameter>): List<CobrancaAgregadoSap> {
+        return buscarAgregado(
+            "cobranca-carteira.sql", "cobranca-carteira-adiantamento.sql",
+            escopo + listOf(
+                Parameter("vencimentoDe", faixa.vencimentoDe(hoje).toString()),
+                Parameter("vencimentoAte", faixa.vencimentoAte(hoje).toString()),
+            ),
+        )
+    }
+
+    // Nota fiscal e adiantamento vivem em views separadas porque UNION nao passa no
+    // parser do SQLQueries - o resultado das duas e concatenado aqui.
+    private inline fun <reified T : Any> buscarAgregado(
+        viewNotaFiscal: String,
+        viewAdiantamento: String,
+        parametros: List<Parameter>,
+    ): List<T> {
+        return sqlQueriesService.getAll<T>(viewNotaFiscal, parametros) +
+            sqlQueriesService.getAll<T>(viewAdiantamento, parametros)
+    }
+
+    private fun porFilial(carteira: List<CobrancaAgregadoSap>): List<CobrancaPorFilial> {
+        return carteira.groupBy { it.BPLId }
+            .map { (bplId, linhas) ->
+                CobrancaPorFilial(
+                    BPLId = bplId,
+                    BPLName = linhas.firstOrNull { it.BPLName != null }?.BPLName,
+                    Saldo = linhas.somaSaldo(),
+                    Parcelas = linhas.somaParcelas(),
+                )
+            }
+            .sortedByDescending { it.Saldo }
+    }
+
+    private fun porStatus(carteira: List<CobrancaAgregadoSap>): List<CobrancaPorStatus> {
+        return carteira.groupBy { it.U_Status?.trim().orEmpty().ifEmpty { SEM_ACOMPANHAMENTO } }
+            .map { (status, linhas) ->
+                CobrancaPorStatus(
+                    Status = status,
+                    Saldo = linhas.somaSaldo(),
+                    Parcelas = linhas.somaParcelas(),
+                )
+            }
+            .sortedByDescending { it.Saldo }
+    }
+
+    private fun porCobrador(
+        recuperado: List<CobrancaRecuperadoSap>,
+        trabalhados: List<CobrancaTrabalhadosSap>,
+        promessas: List<CobrancaAgregadoSap>,
+    ): List<CobrancaPorCobrador> {
+        val recuperadoPorCobrador = recuperado.groupBy { it.U_Cobrador.rotuloCobrador() }
+        val trabalhadosPorCobrador = trabalhados.groupBy { it.U_Usuario.rotuloCobrador() }
+        val promessasPorCobrador = promessas.groupBy { it.U_Cobrador.rotuloCobrador() }
+
+        val cobradores = recuperadoPorCobrador.keys + trabalhadosPorCobrador.keys + promessasPorCobrador.keys
+        return cobradores.map { cobrador ->
+            CobrancaPorCobrador(
+                Cobrador = cobrador,
+                Recuperado = recuperadoPorCobrador[cobrador].orEmpty()
+                    .fold(BigDecimal.ZERO) { acc, it -> acc.add(it.recuperado()) },
+                Documentos = recuperadoPorCobrador[cobrador].orEmpty().sumOf { it.documentos() },
+                TitulosTrabalhados = trabalhadosPorCobrador[cobrador].orEmpty().sumOf { it.titulos() },
+                ParcelasComPromessaVencida = promessasPorCobrador[cobrador].orEmpty().somaParcelas(),
+            )
+        }.sortedByDescending { it.Recuperado }
+    }
+
+    private fun String?.rotuloCobrador(): String = this?.trim().orEmpty().ifEmpty { SEM_COBRADOR }
+
+    private fun List<CobrancaAgregadoSap>.somaSaldo(): BigDecimal =
+        fold(BigDecimal.ZERO) { acc, linha -> acc.add(linha.saldo()) }
+
+    private fun List<CobrancaAgregadoSap>.somaParcelas(): Int = sumOf { it.parcelas() }
+}

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaDashboardService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaDashboardService.kt
@@ -144,7 +144,7 @@ class CobrancaDashboardService(val sqlQueriesService: SqlQueriesService) {
                 Mes = mes.toString(),
                 Rotulo = "${MESES[mes.monthValue - 1]}/${mes.year % 100}",
                 Recuperado = linhas.fold(BigDecimal.ZERO) { acc, it -> acc.add(it.recuperado()) },
-                Documentos = linhas.sumOf { it.documentos() },
+                Documentos = linhas.map { it.DocEntry }.distinct().size,
             )
         }
     }

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaDashboardService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaDashboardService.kt
@@ -22,15 +22,6 @@ import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
-// Agregacoes do dashboard de cobranca. Diferente do CobrancaConsultaService, aqui nao
-// existe paginacao: cada view devolve poucas dezenas de linhas ja somadas pelo SAP.
-//
-// O preco disso e a quantidade de consultas - faixa de aging nao sai de CASE WHEN no
-// parser do SQLQueries, entao cada faixa e uma janela de vencimento separada, e cada
-// familia de numero tem par NF/adiantamento pra o total da carteira fechar com a tela
-// de titulos. Sao ~16 idas ao SAP por resumo(), e e por isso que o resultado e cacheado
-// (ver "cobranca-dashboard" em CacheConfig) e que a serie mensal mora num endpoint
-// proprio, pra tela pintar em duas ondas em vez de esperar tudo.
 @Service
 class CobrancaDashboardService(val sqlQueriesService: SqlQueriesService) {
 
@@ -43,8 +34,6 @@ class CobrancaDashboardService(val sqlQueriesService: SqlQueriesService) {
         )
     }
 
-    // A chave inclui o usuario porque o escopo de vendedor e resolvido aqui dentro:
-    // sem isso a foto de um vendedor poderia ser servida pra outro.
     @Cacheable(
         "cobranca-dashboard",
         key = "'resumo-' + #auth.getIdInt() + '-' + #filial + '-' + #vendedor + '-' + #de + '-' + #ate + '-' + #hoje",
@@ -80,8 +69,6 @@ class CobrancaDashboardService(val sqlQueriesService: SqlQueriesService) {
             escopo + listOf(Parameter("de", de.toString()), Parameter("ate", ate.toString())),
         )
 
-        // Janela anterior de mesma duracao pro delta do card. Reaproveita a mesma view (ela ja
-        // recebe :de/:ate), entao nao ha SQL novo - so duas consultas a mais, dentro do cache.
         val diasDoPeriodo = ChronoUnit.DAYS.between(de, ate) + 1
         val ateAnterior = de.minusDays(1)
         val deAnterior = ateAnterior.minusDays(diasDoPeriodo - 1)
@@ -140,9 +127,6 @@ class CobrancaDashboardService(val sqlQueriesService: SqlQueriesService) {
         val quantidade = meses.coerceIn(1, 24)
         val primeiroMes = YearMonth.from(hoje).minusMonths((quantidade - 1).toLong())
 
-        // Uma consulta cobre a janela inteira: a view agrupa por data crua de pagamento
-        // e o mes e montado aqui, porque nenhuma funcao de data (MONTH, LEFT, TO_CHAR)
-        // tem precedente nas views do projeto.
         val dias = buscarAgregado<CobrancaRecuperadoDiaSap>(
             "cobranca-recuperado-diario.sql", "cobranca-recuperado-diario-adiantamento.sql",
             escopo(auth, filial, vendedor) + listOf(
@@ -153,8 +137,6 @@ class CobrancaDashboardService(val sqlQueriesService: SqlQueriesService) {
 
         val porMes = dias.groupBy { YearMonth.from(LocalDate.parse(it.DocDate, DateTimeFormatter.BASIC_ISO_DATE)) }
 
-        // Mes sem pagamento tem que aparecer como zero, nao desaparecer do grafico -
-        // buraco na serie faz o leitor achar que o mes nao foi medido.
         return (0 until quantidade).map { indice ->
             val mes = primeiroMes.plusMonths(indice.toLong())
             val linhas = porMes[mes] ?: emptyList()
@@ -167,8 +149,6 @@ class CobrancaDashboardService(val sqlQueriesService: SqlQueriesService) {
         }
     }
 
-    // Mesma regra da consulta de titulos (CobrancaConsultaService): quem nao e
-    // super-vendedor so ve a propria carteira, independente do que mandar no parametro.
     private fun escopo(auth: User, filial: Int?, vendedor: Int?): List<Parameter> {
         val vendedorEfetivo = if (auth.superVendedor() == Int.MAX_VALUE) vendedor else auth.getIdInt()
         return listOf(
@@ -189,8 +169,6 @@ class CobrancaDashboardService(val sqlQueriesService: SqlQueriesService) {
         )
     }
 
-    // Nota fiscal e adiantamento vivem em views separadas porque UNION nao passa no
-    // parser do SQLQueries - o resultado das duas e concatenado aqui.
     private inline fun <reified T : Any> buscarAgregado(
         viewNotaFiscal: String,
         viewAdiantamento: String,

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaDominioService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaDominioService.kt
@@ -1,0 +1,75 @@
+package br.andrew.sap.services.cobranca
+
+import br.andrew.sap.infrastructure.odata.Condicao
+import br.andrew.sap.infrastructure.odata.Filter
+import br.andrew.sap.infrastructure.odata.Predicate
+import br.andrew.sap.model.cobranca.CobrancaDominio
+import br.andrew.sap.model.cobranca.CobrancaException
+import br.andrew.sap.model.envrioments.SapEnvrioment
+import br.andrew.sap.services.AuthService
+import br.andrew.sap.services.abstracts.EntitiesService
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestTemplate
+
+@Service
+class CobrancaDominioService(env: SapEnvrioment, restTemplate: RestTemplate, authService: AuthService)
+    : EntitiesService<CobrancaDominio>(env, restTemplate, authService) {
+
+    override fun path(): String = "/b1s/v1/COB_DOMINIO"
+
+    @Cacheable("cobranca-dominio")
+    fun listar(tipo: String? = null): List<CobrancaDominio> {
+        val filtro = Filter(Predicate("U_Ativo", "Y", Condicao.EQUAL))
+        if (tipo != null)
+            filtro.add(Predicate("U_Tipo", tipo, Condicao.EQUAL))
+        return getAll(CobrancaDominio::class.java, filtro)
+            .sortedWith(compareBy({ it.U_Tipo }, { it.U_Ordem ?: 0 }))
+    }
+
+    @CacheEvict("cobranca-dominio", allEntries = true)
+    fun salvar(dominio: CobrancaDominio): CobrancaDominio {
+        val tipo = dominio.U_Tipo ?: throw CobrancaException("Tipo é obrigatório")
+        val codigo = dominio.U_Codigo ?: throw CobrancaException("Código é obrigatório")
+        dominio.Code = CobrancaDominio.code(tipo, codigo)
+
+        val existente = get(Filter(Predicate("Code", dominio.Code!!, Condicao.EQUAL)))
+            .tryGetValues<CobrancaDominio>().firstOrNull()
+
+        return if (existente == null)
+            save(dominio).tryGetValue()
+        else {
+            update(dominio, dominio.Code!!)
+            get(Filter(Predicate("Code", dominio.Code!!, Condicao.EQUAL))).tryGetValues<CobrancaDominio>().first()
+        }
+    }
+
+    fun findOrCreate(tipo: String, codigo: String, descricao: String, ordem: Int) {
+        val code = CobrancaDominio.code(tipo, codigo)
+        val existente = get(Filter(Predicate("Code", code, Condicao.EQUAL))).tryGetValues<CobrancaDominio>()
+        if (existente.isEmpty())
+            salvarComRetentativa(CobrancaDominio(code, tipo, codigo, descricao, ordem, "Y"))
+    }
+
+    // Logo apos o boot criar os UDFs de @COB_DOMINIO, o Service Layer pode demorar
+    // alguns segundos pra reconhecer o campo novo e recusa o primeiro POST com
+    // "Property '...' is invalid" (armadilha documentada no CLAUDE.md do backend).
+    // Como o seeder grava 54 linhas em sequencia logo no boot, isso e reproduzivel;
+    // tenta de novo com espera crescente antes de derrubar a aplicacao.
+    private fun salvarComRetentativa(dominio: CobrancaDominio) {
+        val tentativas = 5
+        val esperaBaseMs = 500L
+        repeat(tentativas) { tentativa ->
+            try {
+                save(dominio)
+                return
+            } catch (e: Exception) {
+                val ultimaTentativa = tentativa == tentativas - 1
+                if (ultimaTentativa || e.message?.contains("is invalid") != true)
+                    throw e
+                Thread.sleep(esperaBaseMs * (tentativa + 1))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaDominioService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaDominioService.kt
@@ -52,11 +52,6 @@ class CobrancaDominioService(env: SapEnvrioment, restTemplate: RestTemplate, aut
             salvarComRetentativa(CobrancaDominio(code, tipo, codigo, descricao, ordem, "Y"))
     }
 
-    // Logo apos o boot criar os UDFs de @COB_DOMINIO, o Service Layer pode demorar
-    // alguns segundos pra reconhecer o campo novo e recusa o primeiro POST com
-    // "Property '...' is invalid" (armadilha documentada no CLAUDE.md do backend).
-    // Como o seeder grava 54 linhas em sequencia logo no boot, isso e reproduzivel;
-    // tenta de novo com espera crescente antes de derrubar a aplicacao.
     private fun salvarComRetentativa(dominio: CobrancaDominio) {
         val tentativas = 5
         val esperaBaseMs = 500L

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaEscopo.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaEscopo.kt
@@ -1,0 +1,14 @@
+package br.andrew.sap.services.cobranca
+
+import br.andrew.sap.model.authentication.User
+
+object CobrancaEscopo {
+
+    fun temAcessoTotal(auth: User): Boolean {
+        return auth.superVendedor() == Int.MAX_VALUE || auth.roles.contains("cobranca")
+    }
+
+    fun vendedorEfetivo(auth: User, vendedorSolicitado: Int?): Int? {
+        return if (temAcessoTotal(auth)) vendedorSolicitado else auth.getIdInt()
+    }
+}

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaService.kt
@@ -26,8 +26,6 @@ class CobrancaService(env: SapEnvrioment, restTemplate: RestTemplate, authServic
 
     override fun path(): String = "/b1s/v1/COB_TITULO"
 
-    // O dashboard e cacheado por 5 minutos; sem esse evict o cobrador registraria a acao
-    // e o card de "sem nenhuma acao" continuaria mostrando o numero velho.
     @CacheEvict("cobranca-dashboard", allEntries = true)
     fun registrarAcao(tipo: String, docEntry: Int, instlmntId: Int, req: CobrancaAcaoRequest, auth: User): CobrancaRegistro {
         validarTipo(tipo)
@@ -69,14 +67,8 @@ class CobrancaService(env: SapEnvrioment, restTemplate: RestTemplate, authServic
             return save(registro).tryGetValue()
         }
 
-        // Preserva o histórico existente (com seus LineId) e só acrescenta a linha nova.
-        // PATCH de coleção filha de UDO substitui o que for enviado; reenviar as linhas
-        // antigas junto é o que garante que elas não somem.
         existente.historico.add(novaLinha)
 
-        // Campo omitido do payload = SAP mantém o valor atual ("não alterar" na tela).
-        // Um campo presente com valor null seria interpretado como limpar o campo, o
-        // que apagaria o que já estava registrado - por isso só entram os informados.
         val payload = mutableMapOf<String, Any?>(
             "U_Cobrador" to cobrador,
             "U_DataAcao" to agora,
@@ -93,9 +85,6 @@ class CobrancaService(env: SapEnvrioment, restTemplate: RestTemplate, authServic
         return buscarPorCode(code) ?: throw CobrancaException("Falha ao reler o registro de cobrança $code")
     }
 
-    // Precisa do evict aqui tambem, e nao so no registrarAcao: a chamada de dentro do map
-    // e auto-invocacao, que nao passa pelo proxy do Spring - o @CacheEvict do registrarAcao
-    // nunca dispararia pelo caminho do lote.
     @CacheEvict("cobranca-dashboard", allEntries = true)
     fun registrarAcaoEmLote(itens: List<CobrancaAcaoLoteItem>, auth: User): List<CobrancaAcaoResultado> {
         return itens.map { item ->

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaService.kt
@@ -61,6 +61,9 @@ class CobrancaService(
             val existente = buscarPorCode(code)
 
             if (existente == null) {
+                consultaService.buscarTituloParaEscopo(tipo, docEntry, instlmntId)
+                    ?: throw CobrancaException("Parcela não encontrada no SAP: $tipo $docEntry/$instlmntId")
+
                 val registro = CobrancaRegistro(
                     Code = code,
                     U_Tipo = tipo,
@@ -111,17 +114,17 @@ class CobrancaService(
     }
 
     fun historico(auth: User, tipo: String, docEntry: Int, instlmntId: Int): List<CobrancaHistorico> {
-        validarEscopo(auth, tipo, docEntry)
+        validarEscopo(auth, tipo, docEntry, instlmntId)
         val code = CobrancaRegistro.code(tipo, docEntry, instlmntId)
         val registro = buscarPorCode(code) ?: return emptyList()
         return registro.historico.sortedByDescending { it.LineId }
     }
 
-    private fun validarEscopo(auth: User, tipo: String, docEntry: Int) {
+    private fun validarEscopo(auth: User, tipo: String, docEntry: Int, instlmntId: Int) {
         if (CobrancaEscopo.temAcessoTotal(auth))
             return
-        val slpCode = consultaService.slpCodeDoTitulo(tipo, docEntry)
-        if (slpCode == null || slpCode != auth.getIdInt())
+        val titulo = consultaService.buscarTituloParaEscopo(tipo, docEntry, instlmntId)
+        if (titulo == null || titulo.SlpCode != auth.getIdInt())
             throw ResponseStatusException(HttpStatus.FORBIDDEN, "Este título não pertence ao seu escopo de vendedor")
     }
 

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaService.kt
@@ -1,0 +1,122 @@
+package br.andrew.sap.services.cobranca
+
+import br.andrew.sap.infrastructure.odata.Condicao
+import br.andrew.sap.infrastructure.odata.Filter
+import br.andrew.sap.infrastructure.odata.Predicate
+import br.andrew.sap.model.authentication.User
+import br.andrew.sap.model.cobranca.CobrancaAcaoLoteItem
+import br.andrew.sap.model.cobranca.CobrancaAcaoRequest
+import br.andrew.sap.model.cobranca.CobrancaAcaoResultado
+import br.andrew.sap.model.cobranca.CobrancaException
+import br.andrew.sap.model.cobranca.CobrancaHistorico
+import br.andrew.sap.model.cobranca.CobrancaRegistro
+import br.andrew.sap.model.envrioments.SapEnvrioment
+import br.andrew.sap.services.AuthService
+import br.andrew.sap.services.abstracts.EntitiesService
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestTemplate
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+
+@Service
+class CobrancaService(env: SapEnvrioment, restTemplate: RestTemplate, authService: AuthService)
+    : EntitiesService<CobrancaRegistro>(env, restTemplate, authService) {
+
+    override fun path(): String = "/b1s/v1/COB_TITULO"
+
+    fun registrarAcao(tipo: String, docEntry: Int, instlmntId: Int, req: CobrancaAcaoRequest, auth: User): CobrancaRegistro {
+        validarTipo(tipo)
+        validar(req)
+        val code = CobrancaRegistro.code(tipo, docEntry, instlmntId)
+        val agora = LocalDate.now().toString()
+        val cobrador = auth._name
+
+        val novaLinha = CobrancaHistorico(
+            U_Data = agora,
+            U_Hora = LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm")),
+            U_Usuario = cobrador,
+            U_Cobrador = cobrador,
+            U_Status = req.status,
+            U_Acao = req.acao,
+            U_Situacao = req.situacao,
+            U_Ocorrencia = req.ocorrencia,
+            U_Observacao = req.observacao,
+        )
+
+        val existente = buscarPorCode(code)
+
+        if (existente == null) {
+            val registro = CobrancaRegistro(
+                Code = code,
+                U_Tipo = tipo,
+                U_DocEntry = docEntry,
+                U_InstlmntID = instlmntId,
+                U_Status = req.status,
+                U_Acao = req.acao,
+                U_Situacao = req.situacao,
+                U_Ocorrencia = req.ocorrencia,
+                U_Observacao = req.observacao,
+                U_Cobrador = cobrador,
+                U_DataAcao = agora,
+                U_DataPromessa = req.dataPromessa,
+                historico = mutableListOf(novaLinha),
+            )
+            return save(registro).tryGetValue()
+        }
+
+        // Preserva o histórico existente (com seus LineId) e só acrescenta a linha nova.
+        // PATCH de coleção filha de UDO substitui o que for enviado; reenviar as linhas
+        // antigas junto é o que garante que elas não somem.
+        existente.historico.add(novaLinha)
+
+        // Campo omitido do payload = SAP mantém o valor atual ("não alterar" na tela).
+        // Um campo presente com valor null seria interpretado como limpar o campo, o
+        // que apagaria o que já estava registrado - por isso só entram os informados.
+        val payload = mutableMapOf<String, Any?>(
+            "U_Cobrador" to cobrador,
+            "U_DataAcao" to agora,
+            "COB_TITULO_LCollection" to existente.historico,
+        )
+        req.status?.let { payload["U_Status"] = it }
+        req.acao?.let { payload["U_Acao"] = it }
+        req.situacao?.let { payload["U_Situacao"] = it }
+        req.ocorrencia?.let { payload["U_Ocorrencia"] = it }
+        req.observacao?.let { payload["U_Observacao"] = it }
+        (req.dataPromessa ?: existente.U_DataPromessa)?.let { payload["U_DataPromessa"] = it }
+
+        update(payload, code)
+        return buscarPorCode(code) ?: throw CobrancaException("Falha ao reler o registro de cobrança $code")
+    }
+
+    fun registrarAcaoEmLote(itens: List<CobrancaAcaoLoteItem>, auth: User): List<CobrancaAcaoResultado> {
+        return itens.map { item ->
+            try {
+                registrarAcao(item.tipo, item.docEntry, item.instlmntId, item.toAcaoRequest(), auth)
+                CobrancaAcaoResultado(item.tipo, item.docEntry, item.instlmntId, success = true)
+            } catch (e: Exception) {
+                CobrancaAcaoResultado(item.tipo, item.docEntry, item.instlmntId, success = false, error = e.message)
+            }
+        }
+    }
+
+    fun historico(tipo: String, docEntry: Int, instlmntId: Int): List<CobrancaHistorico> {
+        val code = CobrancaRegistro.code(tipo, docEntry, instlmntId)
+        val registro = buscarPorCode(code) ?: return emptyList()
+        return registro.historico.sortedByDescending { it.LineId }
+    }
+
+    private fun buscarPorCode(code: String): CobrancaRegistro? {
+        return get(Filter(Predicate("Code", code, Condicao.EQUAL))).tryGetValues<CobrancaRegistro>().firstOrNull()
+    }
+
+    private fun validar(req: CobrancaAcaoRequest) {
+        if (req.observacao.isNullOrBlank() && req.ocorrencia.isNullOrBlank())
+            throw CobrancaException("Informe uma observação ou selecione uma ocorrência do que foi feito.")
+    }
+
+    private fun validarTipo(tipo: String) {
+        if (tipo != CobrancaRegistro.TIPO_NOTA_FISCAL && tipo != CobrancaRegistro.TIPO_ADIANTAMENTO)
+            throw CobrancaException("Tipo de título inválido: $tipo")
+    }
+}

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaService.kt
@@ -13,6 +13,7 @@ import br.andrew.sap.model.cobranca.CobrancaRegistro
 import br.andrew.sap.model.envrioments.SapEnvrioment
 import br.andrew.sap.services.AuthService
 import br.andrew.sap.services.abstracts.EntitiesService
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestTemplate
 import java.time.LocalDate
@@ -25,6 +26,9 @@ class CobrancaService(env: SapEnvrioment, restTemplate: RestTemplate, authServic
 
     override fun path(): String = "/b1s/v1/COB_TITULO"
 
+    // O dashboard e cacheado por 5 minutos; sem esse evict o cobrador registraria a acao
+    // e o card de "sem nenhuma acao" continuaria mostrando o numero velho.
+    @CacheEvict("cobranca-dashboard", allEntries = true)
     fun registrarAcao(tipo: String, docEntry: Int, instlmntId: Int, req: CobrancaAcaoRequest, auth: User): CobrancaRegistro {
         validarTipo(tipo)
         validar(req)
@@ -89,6 +93,10 @@ class CobrancaService(env: SapEnvrioment, restTemplate: RestTemplate, authServic
         return buscarPorCode(code) ?: throw CobrancaException("Falha ao reler o registro de cobrança $code")
     }
 
+    // Precisa do evict aqui tambem, e nao so no registrarAcao: a chamada de dentro do map
+    // e auto-invocacao, que nao passa pelo proxy do Spring - o @CacheEvict do registrarAcao
+    // nunca dispararia pelo caminho do lote.
+    @CacheEvict("cobranca-dashboard", allEntries = true)
     fun registrarAcaoEmLote(itens: List<CobrancaAcaoLoteItem>, auth: User): List<CobrancaAcaoResultado> {
         return itens.map { item ->
             try {

--- a/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaService.kt
+++ b/src/main/kotlin/br/andrew/sap/services/cobranca/CobrancaService.kt
@@ -14,15 +14,26 @@ import br.andrew.sap.model.envrioments.SapEnvrioment
 import br.andrew.sap.services.AuthService
 import br.andrew.sap.services.abstracts.EntitiesService
 import org.springframework.cache.annotation.CacheEvict
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestTemplate
+import org.springframework.web.server.ResponseStatusException
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
+import java.util.concurrent.ConcurrentHashMap
 
 @Service
-class CobrancaService(env: SapEnvrioment, restTemplate: RestTemplate, authService: AuthService)
-    : EntitiesService<CobrancaRegistro>(env, restTemplate, authService) {
+class CobrancaService(
+    env: SapEnvrioment,
+    restTemplate: RestTemplate,
+    authService: AuthService,
+    val consultaService: CobrancaConsultaService,
+) : EntitiesService<CobrancaRegistro>(env, restTemplate, authService) {
+
+    // Lock em memoria - so protege dentro do mesmo processo. Nao cobre a janela breve de
+    // deploy com 2 instancias simultaneas, aceita como risco residual (ver PR).
+    private val locksPorTitulo = ConcurrentHashMap<String, Any>()
 
     override fun path(): String = "/b1s/v1/COB_TITULO"
 
@@ -46,43 +57,45 @@ class CobrancaService(env: SapEnvrioment, restTemplate: RestTemplate, authServic
             U_Observacao = req.observacao,
         )
 
-        val existente = buscarPorCode(code)
+        synchronized(locksPorTitulo.computeIfAbsent(code) { Any() }) {
+            val existente = buscarPorCode(code)
 
-        if (existente == null) {
-            val registro = CobrancaRegistro(
-                Code = code,
-                U_Tipo = tipo,
-                U_DocEntry = docEntry,
-                U_InstlmntID = instlmntId,
-                U_Status = req.status,
-                U_Acao = req.acao,
-                U_Situacao = req.situacao,
-                U_Ocorrencia = req.ocorrencia,
-                U_Observacao = req.observacao,
-                U_Cobrador = cobrador,
-                U_DataAcao = agora,
-                U_DataPromessa = req.dataPromessa,
-                historico = mutableListOf(novaLinha),
+            if (existente == null) {
+                val registro = CobrancaRegistro(
+                    Code = code,
+                    U_Tipo = tipo,
+                    U_DocEntry = docEntry,
+                    U_InstlmntID = instlmntId,
+                    U_Status = req.status,
+                    U_Acao = req.acao,
+                    U_Situacao = req.situacao,
+                    U_Ocorrencia = req.ocorrencia,
+                    U_Observacao = req.observacao,
+                    U_Cobrador = cobrador,
+                    U_DataAcao = agora,
+                    U_DataPromessa = req.dataPromessa,
+                    historico = mutableListOf(novaLinha),
+                )
+                return save(registro).tryGetValue()
+            }
+
+            existente.historico.add(novaLinha)
+
+            val payload = mutableMapOf<String, Any?>(
+                "U_Cobrador" to cobrador,
+                "U_DataAcao" to agora,
+                "COB_TITULO_LCollection" to existente.historico,
             )
-            return save(registro).tryGetValue()
+            req.status?.let { payload["U_Status"] = it }
+            req.acao?.let { payload["U_Acao"] = it }
+            req.situacao?.let { payload["U_Situacao"] = it }
+            req.ocorrencia?.let { payload["U_Ocorrencia"] = it }
+            req.observacao?.let { payload["U_Observacao"] = it }
+            (req.dataPromessa ?: existente.U_DataPromessa)?.let { payload["U_DataPromessa"] = it }
+
+            update(payload, code)
+            return buscarPorCode(code) ?: throw CobrancaException("Falha ao reler o registro de cobrança $code")
         }
-
-        existente.historico.add(novaLinha)
-
-        val payload = mutableMapOf<String, Any?>(
-            "U_Cobrador" to cobrador,
-            "U_DataAcao" to agora,
-            "COB_TITULO_LCollection" to existente.historico,
-        )
-        req.status?.let { payload["U_Status"] = it }
-        req.acao?.let { payload["U_Acao"] = it }
-        req.situacao?.let { payload["U_Situacao"] = it }
-        req.ocorrencia?.let { payload["U_Ocorrencia"] = it }
-        req.observacao?.let { payload["U_Observacao"] = it }
-        (req.dataPromessa ?: existente.U_DataPromessa)?.let { payload["U_DataPromessa"] = it }
-
-        update(payload, code)
-        return buscarPorCode(code) ?: throw CobrancaException("Falha ao reler o registro de cobrança $code")
     }
 
     @CacheEvict("cobranca-dashboard", allEntries = true)
@@ -97,10 +110,19 @@ class CobrancaService(env: SapEnvrioment, restTemplate: RestTemplate, authServic
         }
     }
 
-    fun historico(tipo: String, docEntry: Int, instlmntId: Int): List<CobrancaHistorico> {
+    fun historico(auth: User, tipo: String, docEntry: Int, instlmntId: Int): List<CobrancaHistorico> {
+        validarEscopo(auth, tipo, docEntry)
         val code = CobrancaRegistro.code(tipo, docEntry, instlmntId)
         val registro = buscarPorCode(code) ?: return emptyList()
         return registro.historico.sortedByDescending { it.LineId }
+    }
+
+    private fun validarEscopo(auth: User, tipo: String, docEntry: Int) {
+        if (CobrancaEscopo.temAcessoTotal(auth))
+            return
+        val slpCode = consultaService.slpCodeDoTitulo(tipo, docEntry)
+        if (slpCode == null || slpCode != auth.getIdInt())
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Este título não pertence ao seu escopo de vendedor")
     }
 
     private fun buscarPorCode(code: String): CobrancaRegistro? {

--- a/src/main/resources/rules.yml
+++ b/src/main/resources/rules.yml
@@ -52,6 +52,10 @@ roles:
       actions: ["get"]
     - url: "/down-payment/contrato-venda-futura/*/pix"
       actions: [ "post" ]
+    - url: "/cobranca/titulos"
+      actions: ["get"]
+    - url: "/cobranca/titulos/*/*/*/historico"
+      actions: ["get"]
 
   vendedor_admin:
     - url: "/down-payment/contrato-venda-futura/*/pix"
@@ -109,6 +113,17 @@ roles:
       actions: ["get"]
     - url: "/sysfeed/status"
       actions: ["post"]
+
+  cobranca:
+    - url: "/cobranca/**"
+      actions: ["get", "post"]
+    - url: "/business-partners/search"
+      actions: ["*"]
+    - url: "/branch"
+      actions: ["get"]
+    - url: "/sales-person/search"
+      actions: ["*"]
+
   qualidade:
     - url: "/batch-stock/item-code/**"
       actions: ["get"]

--- a/src/main/resources/views/cobranca/cobranca-carteira-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-carteira-adiantamento.sql
@@ -1,0 +1,20 @@
+SELECT
+    T0."BPLId", T0."BPLName",
+    C."U_Status",
+    sum(P."InsTotal")   AS "Total",
+    sum(P."PaidToDate") AS "Pago",
+    count(P."InstlmntID") AS "Parcelas"
+FROM ODPI T0
+    INNER JOIN DPI6 P ON P."DocEntry" = T0."DocEntry"
+    LEFT JOIN "@COB_TITULO" C
+         ON C."U_Tipo" = 'AD' AND C."U_DocEntry" = T0."DocEntry" AND C."U_InstlmntID" = P."InstlmntID"
+WHERE
+    T0."CANCELED" = 'N'
+    AND P."InsTotal" <> 0
+    AND P."Status" = 'O'
+    AND P."DueDate" >= :vencimentoDe
+    AND P."DueDate" <= :vencimentoAte
+    AND (T0."BPLId"   = :filial   OR T0."BPLId"   < :filialIsFilter)
+    AND (T0."SlpCode" = :vendedor OR T0."SlpCode" < :vendedorIsFilter)
+GROUP BY
+    T0."BPLId", T0."BPLName", C."U_Status"

--- a/src/main/resources/views/cobranca/cobranca-carteira-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-carteira-adiantamento.sql
@@ -16,5 +16,6 @@ WHERE
     AND P."DueDate" <= :vencimentoAte
     AND (T0."BPLId"   = :filial   OR T0."BPLId"   < :filialIsFilter)
     AND (T0."SlpCode" = :vendedor OR T0."SlpCode" < :vendedorIsFilter)
+    AND T0."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
 GROUP BY
     T0."BPLId", T0."BPLName", C."U_Status"

--- a/src/main/resources/views/cobranca/cobranca-carteira.sql
+++ b/src/main/resources/views/cobranca/cobranca-carteira.sql
@@ -1,0 +1,20 @@
+SELECT
+    NS."BPLId", NS."BPLName",
+    C."U_Status",
+    sum(P."InsTotal")   AS "Total",
+    sum(P."PaidToDate") AS "Pago",
+    count(P."InstlmntID") AS "Parcelas"
+FROM OINV NS
+    INNER JOIN INV6 P ON P."DocEntry" = NS."DocEntry"
+    LEFT JOIN "@COB_TITULO" C
+         ON C."U_Tipo" = 'NF' AND C."U_DocEntry" = NS."DocEntry" AND C."U_InstlmntID" = P."InstlmntID"
+WHERE
+    NS."CANCELED" = 'N'
+    AND P."InsTotal" <> 0
+    AND P."Status" = 'O'
+    AND P."DueDate" >= :vencimentoDe
+    AND P."DueDate" <= :vencimentoAte
+    AND (NS."BPLId"   = :filial   OR NS."BPLId"   < :filialIsFilter)
+    AND (NS."SlpCode" = :vendedor OR NS."SlpCode" < :vendedorIsFilter)
+GROUP BY
+    NS."BPLId", NS."BPLName", C."U_Status"

--- a/src/main/resources/views/cobranca/cobranca-carteira.sql
+++ b/src/main/resources/views/cobranca/cobranca-carteira.sql
@@ -16,5 +16,6 @@ WHERE
     AND P."DueDate" <= :vencimentoAte
     AND (NS."BPLId"   = :filial   OR NS."BPLId"   < :filialIsFilter)
     AND (NS."SlpCode" = :vendedor OR NS."SlpCode" < :vendedorIsFilter)
+    AND NS."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
 GROUP BY
     NS."BPLId", NS."BPLName", C."U_Status"

--- a/src/main/resources/views/cobranca/cobranca-promessa-vencida-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-promessa-vencida-adiantamento.sql
@@ -1,0 +1,19 @@
+SELECT
+    T0."BPLId", T0."BPLName",
+    C."U_Cobrador",
+    sum(P."InsTotal")   AS "Total",
+    sum(P."PaidToDate") AS "Pago",
+    count(P."InstlmntID") AS "Parcelas"
+FROM ODPI T0
+    INNER JOIN DPI6 P ON P."DocEntry" = T0."DocEntry"
+    INNER JOIN "@COB_TITULO" C
+         ON C."U_Tipo" = 'AD' AND C."U_DocEntry" = T0."DocEntry" AND C."U_InstlmntID" = P."InstlmntID"
+WHERE
+    T0."CANCELED" = 'N'
+    AND P."InsTotal" <> 0
+    AND P."Status" = 'O'
+    AND C."U_DataPromessa" <= :data
+    AND (T0."BPLId"   = :filial   OR T0."BPLId"   < :filialIsFilter)
+    AND (T0."SlpCode" = :vendedor OR T0."SlpCode" < :vendedorIsFilter)
+GROUP BY
+    T0."BPLId", T0."BPLName", C."U_Cobrador"

--- a/src/main/resources/views/cobranca/cobranca-promessa-vencida-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-promessa-vencida-adiantamento.sql
@@ -15,5 +15,6 @@ WHERE
     AND C."U_DataPromessa" <= :data
     AND (T0."BPLId"   = :filial   OR T0."BPLId"   < :filialIsFilter)
     AND (T0."SlpCode" = :vendedor OR T0."SlpCode" < :vendedorIsFilter)
+    AND T0."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
 GROUP BY
     T0."BPLId", T0."BPLName", C."U_Cobrador"

--- a/src/main/resources/views/cobranca/cobranca-promessa-vencida.sql
+++ b/src/main/resources/views/cobranca/cobranca-promessa-vencida.sql
@@ -1,0 +1,19 @@
+SELECT
+    NS."BPLId", NS."BPLName",
+    C."U_Cobrador",
+    sum(P."InsTotal")   AS "Total",
+    sum(P."PaidToDate") AS "Pago",
+    count(P."InstlmntID") AS "Parcelas"
+FROM OINV NS
+    INNER JOIN INV6 P ON P."DocEntry" = NS."DocEntry"
+    INNER JOIN "@COB_TITULO" C
+         ON C."U_Tipo" = 'NF' AND C."U_DocEntry" = NS."DocEntry" AND C."U_InstlmntID" = P."InstlmntID"
+WHERE
+    NS."CANCELED" = 'N'
+    AND P."InsTotal" <> 0
+    AND P."Status" = 'O'
+    AND C."U_DataPromessa" <= :data
+    AND (NS."BPLId"   = :filial   OR NS."BPLId"   < :filialIsFilter)
+    AND (NS."SlpCode" = :vendedor OR NS."SlpCode" < :vendedorIsFilter)
+GROUP BY
+    NS."BPLId", NS."BPLName", C."U_Cobrador"

--- a/src/main/resources/views/cobranca/cobranca-promessa-vencida.sql
+++ b/src/main/resources/views/cobranca/cobranca-promessa-vencida.sql
@@ -15,5 +15,6 @@ WHERE
     AND C."U_DataPromessa" <= :data
     AND (NS."BPLId"   = :filial   OR NS."BPLId"   < :filialIsFilter)
     AND (NS."SlpCode" = :vendedor OR NS."SlpCode" < :vendedorIsFilter)
+    AND NS."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
 GROUP BY
     NS."BPLId", NS."BPLName", C."U_Cobrador"

--- a/src/main/resources/views/cobranca/cobranca-recuperado-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-recuperado-adiantamento.sql
@@ -16,5 +16,6 @@ WHERE
     AND EXISTS(SELECT 1 FROM "@COB_TITULO_L" H WHERE H."Code" = C."Code" AND H."U_Data" <= r."DocDate")
     AND (T0."BPLId"   = :filial   OR T0."BPLId"   < :filialIsFilter)
     AND (T0."SlpCode" = :vendedor OR T0."SlpCode" < :vendedorIsFilter)
+    AND T0."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
 GROUP BY
     C."U_Cobrador", T0."BPLId", T0."BPLName"

--- a/src/main/resources/views/cobranca/cobranca-recuperado-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-recuperado-adiantamento.sql
@@ -1,0 +1,20 @@
+SELECT
+    C."U_Cobrador",
+    T0."BPLId", T0."BPLName",
+    sum(l."SumApplied") AS "Recuperado",
+    count(DISTINCT T0."DocEntry") AS "Documentos"
+FROM RCT2 l
+    INNER JOIN ORCT r ON r."DocEntry" = l."DocNum"
+    INNER JOIN ODPI T0 ON T0."DocEntry" = l."DocEntry"
+    INNER JOIN "@COB_TITULO" C
+         ON C."U_Tipo" = 'AD' AND C."U_DocEntry" = l."DocEntry" AND C."U_InstlmntID" = l."InstId"
+WHERE
+    (r."Canceled" = 'N' OR r."Canceled" IS NULL)
+    AND l."InvType" = 203
+    AND r."DocDate" >= :de
+    AND r."DocDate" <= :ate
+    AND EXISTS(SELECT 1 FROM "@COB_TITULO_L" H WHERE H."Code" = C."Code" AND H."U_Data" <= r."DocDate")
+    AND (T0."BPLId"   = :filial   OR T0."BPLId"   < :filialIsFilter)
+    AND (T0."SlpCode" = :vendedor OR T0."SlpCode" < :vendedorIsFilter)
+GROUP BY
+    C."U_Cobrador", T0."BPLId", T0."BPLName"

--- a/src/main/resources/views/cobranca/cobranca-recuperado-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-recuperado-adiantamento.sql
@@ -1,5 +1,5 @@
 SELECT
-    C."U_Cobrador",
+    H."U_Cobrador",
     T0."BPLId", T0."BPLName",
     sum(l."SumApplied") AS "Recuperado",
     count(DISTINCT T0."DocEntry") AS "Documentos"
@@ -8,14 +8,20 @@ FROM RCT2 l
     INNER JOIN ODPI T0 ON T0."DocEntry" = l."DocEntry"
     INNER JOIN "@COB_TITULO" C
          ON C."U_Tipo" = 'AD' AND C."U_DocEntry" = l."DocEntry" AND C."U_InstlmntID" = l."InstId"
+    INNER JOIN "@COB_TITULO_L" H
+         ON H."Code" = C."Code" AND H."U_Data" <= r."DocDate"
 WHERE
     (r."Canceled" = 'N' OR r."Canceled" IS NULL)
     AND l."InvType" = 203
     AND r."DocDate" >= :de
     AND r."DocDate" <= :ate
-    AND EXISTS(SELECT 1 FROM "@COB_TITULO_L" H WHERE H."Code" = C."Code" AND H."U_Data" <= r."DocDate")
+    AND NOT EXISTS (
+        SELECT 1 FROM "@COB_TITULO_L" H2
+        WHERE H2."Code" = H."Code" AND H2."U_Data" <= r."DocDate"
+          AND (H2."U_Data" > H."U_Data" OR (H2."U_Data" = H."U_Data" AND H2."LineId" > H."LineId"))
+    )
     AND (T0."BPLId"   = :filial   OR T0."BPLId"   < :filialIsFilter)
     AND (T0."SlpCode" = :vendedor OR T0."SlpCode" < :vendedorIsFilter)
     AND T0."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
 GROUP BY
-    C."U_Cobrador", T0."BPLId", T0."BPLName"
+    H."U_Cobrador", T0."BPLId", T0."BPLName"

--- a/src/main/resources/views/cobranca/cobranca-recuperado-diario-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-recuperado-diario-adiantamento.sql
@@ -15,6 +15,7 @@ WHERE
     AND EXISTS(SELECT 1 FROM "@COB_TITULO_L" H WHERE H."Code" = C."Code" AND H."U_Data" <= r."DocDate")
     AND (T0."BPLId"   = :filial   OR T0."BPLId"   < :filialIsFilter)
     AND (T0."SlpCode" = :vendedor OR T0."SlpCode" < :vendedorIsFilter)
+    AND T0."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
 GROUP BY
     r."DocDate"
 ORDER BY

--- a/src/main/resources/views/cobranca/cobranca-recuperado-diario-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-recuperado-diario-adiantamento.sql
@@ -1,7 +1,7 @@
 SELECT
     r."DocDate",
-    sum(l."SumApplied") AS "Recuperado",
-    count(DISTINCT T0."DocEntry") AS "Documentos"
+    l."SumApplied" AS "Recuperado",
+    T0."DocEntry"
 FROM RCT2 l
     INNER JOIN ORCT r ON r."DocEntry" = l."DocNum"
     INNER JOIN ODPI T0 ON T0."DocEntry" = l."DocEntry"
@@ -16,7 +16,5 @@ WHERE
     AND (T0."BPLId"   = :filial   OR T0."BPLId"   < :filialIsFilter)
     AND (T0."SlpCode" = :vendedor OR T0."SlpCode" < :vendedorIsFilter)
     AND T0."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
-GROUP BY
-    r."DocDate"
 ORDER BY
     r."DocDate"

--- a/src/main/resources/views/cobranca/cobranca-recuperado-diario-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-recuperado-diario-adiantamento.sql
@@ -1,0 +1,21 @@
+SELECT
+    r."DocDate",
+    sum(l."SumApplied") AS "Recuperado",
+    count(DISTINCT T0."DocEntry") AS "Documentos"
+FROM RCT2 l
+    INNER JOIN ORCT r ON r."DocEntry" = l."DocNum"
+    INNER JOIN ODPI T0 ON T0."DocEntry" = l."DocEntry"
+    INNER JOIN "@COB_TITULO" C
+         ON C."U_Tipo" = 'AD' AND C."U_DocEntry" = l."DocEntry" AND C."U_InstlmntID" = l."InstId"
+WHERE
+    (r."Canceled" = 'N' OR r."Canceled" IS NULL)
+    AND l."InvType" = 203
+    AND r."DocDate" >= :de
+    AND r."DocDate" <= :ate
+    AND EXISTS(SELECT 1 FROM "@COB_TITULO_L" H WHERE H."Code" = C."Code" AND H."U_Data" <= r."DocDate")
+    AND (T0."BPLId"   = :filial   OR T0."BPLId"   < :filialIsFilter)
+    AND (T0."SlpCode" = :vendedor OR T0."SlpCode" < :vendedorIsFilter)
+GROUP BY
+    r."DocDate"
+ORDER BY
+    r."DocDate"

--- a/src/main/resources/views/cobranca/cobranca-recuperado-diario.sql
+++ b/src/main/resources/views/cobranca/cobranca-recuperado-diario.sql
@@ -1,0 +1,21 @@
+SELECT
+    r."DocDate",
+    sum(l."SumApplied") AS "Recuperado",
+    count(DISTINCT NS."DocEntry") AS "Documentos"
+FROM RCT2 l
+    INNER JOIN ORCT r ON r."DocEntry" = l."DocNum"
+    INNER JOIN OINV NS ON NS."DocEntry" = l."DocEntry"
+    INNER JOIN "@COB_TITULO" C
+         ON C."U_Tipo" = 'NF' AND C."U_DocEntry" = l."DocEntry" AND C."U_InstlmntID" = l."InstId"
+WHERE
+    (r."Canceled" = 'N' OR r."Canceled" IS NULL)
+    AND l."InvType" = 13
+    AND r."DocDate" >= :de
+    AND r."DocDate" <= :ate
+    AND EXISTS(SELECT 1 FROM "@COB_TITULO_L" H WHERE H."Code" = C."Code" AND H."U_Data" <= r."DocDate")
+    AND (NS."BPLId"   = :filial   OR NS."BPLId"   < :filialIsFilter)
+    AND (NS."SlpCode" = :vendedor OR NS."SlpCode" < :vendedorIsFilter)
+GROUP BY
+    r."DocDate"
+ORDER BY
+    r."DocDate"

--- a/src/main/resources/views/cobranca/cobranca-recuperado-diario.sql
+++ b/src/main/resources/views/cobranca/cobranca-recuperado-diario.sql
@@ -15,6 +15,7 @@ WHERE
     AND EXISTS(SELECT 1 FROM "@COB_TITULO_L" H WHERE H."Code" = C."Code" AND H."U_Data" <= r."DocDate")
     AND (NS."BPLId"   = :filial   OR NS."BPLId"   < :filialIsFilter)
     AND (NS."SlpCode" = :vendedor OR NS."SlpCode" < :vendedorIsFilter)
+    AND NS."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
 GROUP BY
     r."DocDate"
 ORDER BY

--- a/src/main/resources/views/cobranca/cobranca-recuperado-diario.sql
+++ b/src/main/resources/views/cobranca/cobranca-recuperado-diario.sql
@@ -1,7 +1,7 @@
 SELECT
     r."DocDate",
-    sum(l."SumApplied") AS "Recuperado",
-    count(DISTINCT NS."DocEntry") AS "Documentos"
+    l."SumApplied" AS "Recuperado",
+    NS."DocEntry"
 FROM RCT2 l
     INNER JOIN ORCT r ON r."DocEntry" = l."DocNum"
     INNER JOIN OINV NS ON NS."DocEntry" = l."DocEntry"
@@ -16,7 +16,5 @@ WHERE
     AND (NS."BPLId"   = :filial   OR NS."BPLId"   < :filialIsFilter)
     AND (NS."SlpCode" = :vendedor OR NS."SlpCode" < :vendedorIsFilter)
     AND NS."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
-GROUP BY
-    r."DocDate"
 ORDER BY
     r."DocDate"

--- a/src/main/resources/views/cobranca/cobranca-recuperado.sql
+++ b/src/main/resources/views/cobranca/cobranca-recuperado.sql
@@ -16,5 +16,6 @@ WHERE
     AND EXISTS(SELECT 1 FROM "@COB_TITULO_L" H WHERE H."Code" = C."Code" AND H."U_Data" <= r."DocDate")
     AND (NS."BPLId"   = :filial   OR NS."BPLId"   < :filialIsFilter)
     AND (NS."SlpCode" = :vendedor OR NS."SlpCode" < :vendedorIsFilter)
+    AND NS."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
 GROUP BY
     C."U_Cobrador", NS."BPLId", NS."BPLName"

--- a/src/main/resources/views/cobranca/cobranca-recuperado.sql
+++ b/src/main/resources/views/cobranca/cobranca-recuperado.sql
@@ -1,0 +1,20 @@
+SELECT
+    C."U_Cobrador",
+    NS."BPLId", NS."BPLName",
+    sum(l."SumApplied") AS "Recuperado",
+    count(DISTINCT NS."DocEntry") AS "Documentos"
+FROM RCT2 l
+    INNER JOIN ORCT r ON r."DocEntry" = l."DocNum"
+    INNER JOIN OINV NS ON NS."DocEntry" = l."DocEntry"
+    INNER JOIN "@COB_TITULO" C
+         ON C."U_Tipo" = 'NF' AND C."U_DocEntry" = l."DocEntry" AND C."U_InstlmntID" = l."InstId"
+WHERE
+    (r."Canceled" = 'N' OR r."Canceled" IS NULL)
+    AND l."InvType" = 13
+    AND r."DocDate" >= :de
+    AND r."DocDate" <= :ate
+    AND EXISTS(SELECT 1 FROM "@COB_TITULO_L" H WHERE H."Code" = C."Code" AND H."U_Data" <= r."DocDate")
+    AND (NS."BPLId"   = :filial   OR NS."BPLId"   < :filialIsFilter)
+    AND (NS."SlpCode" = :vendedor OR NS."SlpCode" < :vendedorIsFilter)
+GROUP BY
+    C."U_Cobrador", NS."BPLId", NS."BPLName"

--- a/src/main/resources/views/cobranca/cobranca-recuperado.sql
+++ b/src/main/resources/views/cobranca/cobranca-recuperado.sql
@@ -1,5 +1,5 @@
 SELECT
-    C."U_Cobrador",
+    H."U_Cobrador",
     NS."BPLId", NS."BPLName",
     sum(l."SumApplied") AS "Recuperado",
     count(DISTINCT NS."DocEntry") AS "Documentos"
@@ -8,14 +8,20 @@ FROM RCT2 l
     INNER JOIN OINV NS ON NS."DocEntry" = l."DocEntry"
     INNER JOIN "@COB_TITULO" C
          ON C."U_Tipo" = 'NF' AND C."U_DocEntry" = l."DocEntry" AND C."U_InstlmntID" = l."InstId"
+    INNER JOIN "@COB_TITULO_L" H
+         ON H."Code" = C."Code" AND H."U_Data" <= r."DocDate"
 WHERE
     (r."Canceled" = 'N' OR r."Canceled" IS NULL)
     AND l."InvType" = 13
     AND r."DocDate" >= :de
     AND r."DocDate" <= :ate
-    AND EXISTS(SELECT 1 FROM "@COB_TITULO_L" H WHERE H."Code" = C."Code" AND H."U_Data" <= r."DocDate")
+    AND NOT EXISTS (
+        SELECT 1 FROM "@COB_TITULO_L" H2
+        WHERE H2."Code" = H."Code" AND H2."U_Data" <= r."DocDate"
+          AND (H2."U_Data" > H."U_Data" OR (H2."U_Data" = H."U_Data" AND H2."LineId" > H."LineId"))
+    )
     AND (NS."BPLId"   = :filial   OR NS."BPLId"   < :filialIsFilter)
     AND (NS."SlpCode" = :vendedor OR NS."SlpCode" < :vendedorIsFilter)
     AND NS."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
 GROUP BY
-    C."U_Cobrador", NS."BPLId", NS."BPLName"
+    H."U_Cobrador", NS."BPLId", NS."BPLName"

--- a/src/main/resources/views/cobranca/cobranca-sem-acao-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-sem-acao-adiantamento.sql
@@ -15,5 +15,6 @@ WHERE
     AND C."Code" IS NULL
     AND (T0."BPLId"   = :filial   OR T0."BPLId"   < :filialIsFilter)
     AND (T0."SlpCode" = :vendedor OR T0."SlpCode" < :vendedorIsFilter)
+    AND T0."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
 GROUP BY
     T0."BPLId", T0."BPLName"

--- a/src/main/resources/views/cobranca/cobranca-sem-acao-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-sem-acao-adiantamento.sql
@@ -1,0 +1,19 @@
+SELECT
+    T0."BPLId", T0."BPLName",
+    sum(P."InsTotal")   AS "Total",
+    sum(P."PaidToDate") AS "Pago",
+    count(P."InstlmntID") AS "Parcelas"
+FROM ODPI T0
+    INNER JOIN DPI6 P ON P."DocEntry" = T0."DocEntry"
+    LEFT JOIN "@COB_TITULO" C
+         ON C."U_Tipo" = 'AD' AND C."U_DocEntry" = T0."DocEntry" AND C."U_InstlmntID" = P."InstlmntID"
+WHERE
+    T0."CANCELED" = 'N'
+    AND P."InsTotal" <> 0
+    AND P."Status" = 'O'
+    AND P."DueDate" <= :data
+    AND C."Code" IS NULL
+    AND (T0."BPLId"   = :filial   OR T0."BPLId"   < :filialIsFilter)
+    AND (T0."SlpCode" = :vendedor OR T0."SlpCode" < :vendedorIsFilter)
+GROUP BY
+    T0."BPLId", T0."BPLName"

--- a/src/main/resources/views/cobranca/cobranca-sem-acao.sql
+++ b/src/main/resources/views/cobranca/cobranca-sem-acao.sql
@@ -1,0 +1,19 @@
+SELECT
+    NS."BPLId", NS."BPLName",
+    sum(P."InsTotal")   AS "Total",
+    sum(P."PaidToDate") AS "Pago",
+    count(P."InstlmntID") AS "Parcelas"
+FROM OINV NS
+    INNER JOIN INV6 P ON P."DocEntry" = NS."DocEntry"
+    LEFT JOIN "@COB_TITULO" C
+         ON C."U_Tipo" = 'NF' AND C."U_DocEntry" = NS."DocEntry" AND C."U_InstlmntID" = P."InstlmntID"
+WHERE
+    NS."CANCELED" = 'N'
+    AND P."InsTotal" <> 0
+    AND P."Status" = 'O'
+    AND P."DueDate" <= :data
+    AND C."Code" IS NULL
+    AND (NS."BPLId"   = :filial   OR NS."BPLId"   < :filialIsFilter)
+    AND (NS."SlpCode" = :vendedor OR NS."SlpCode" < :vendedorIsFilter)
+GROUP BY
+    NS."BPLId", NS."BPLName"

--- a/src/main/resources/views/cobranca/cobranca-sem-acao.sql
+++ b/src/main/resources/views/cobranca/cobranca-sem-acao.sql
@@ -15,5 +15,6 @@ WHERE
     AND C."Code" IS NULL
     AND (NS."BPLId"   = :filial   OR NS."BPLId"   < :filialIsFilter)
     AND (NS."SlpCode" = :vendedor OR NS."SlpCode" < :vendedorIsFilter)
+    AND NS."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
 GROUP BY
     NS."BPLId", NS."BPLName"

--- a/src/main/resources/views/cobranca/cobranca-titulo-vendedor-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-titulo-vendedor-adiantamento.sql
@@ -1,0 +1,5 @@
+SELECT
+    T0."SlpCode"
+FROM ODPI T0
+WHERE
+    T0."DocEntry" = :docEntry

--- a/src/main/resources/views/cobranca/cobranca-titulo-vendedor-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-titulo-vendedor-adiantamento.sql
@@ -1,5 +1,7 @@
 SELECT
     T0."SlpCode"
 FROM ODPI T0
+    INNER JOIN DPI6 P ON P."DocEntry" = T0."DocEntry"
 WHERE
     T0."DocEntry" = :docEntry
+    AND P."InstlmntID" = :instlmntId

--- a/src/main/resources/views/cobranca/cobranca-titulo-vendedor.sql
+++ b/src/main/resources/views/cobranca/cobranca-titulo-vendedor.sql
@@ -1,5 +1,7 @@
 SELECT
     NS."SlpCode"
 FROM OINV NS
+    INNER JOIN INV6 P ON P."DocEntry" = NS."DocEntry"
 WHERE
     NS."DocEntry" = :docEntry
+    AND P."InstlmntID" = :instlmntId

--- a/src/main/resources/views/cobranca/cobranca-titulo-vendedor.sql
+++ b/src/main/resources/views/cobranca/cobranca-titulo-vendedor.sql
@@ -1,0 +1,5 @@
+SELECT
+    NS."SlpCode"
+FROM OINV NS
+WHERE
+    NS."DocEntry" = :docEntry

--- a/src/main/resources/views/cobranca/cobranca-titulos-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-titulos-adiantamento.sql
@@ -27,6 +27,8 @@ WHERE
     AND (C."U_Status"    = :status   OR T0."DocEntry" < :statusIsFilter)
     AND (C."U_Cobrador"  = :cobrador OR T0."DocEntry" < :cobradorIsFilter)
     AND (C."U_Situacao"  = :situacao OR T0."DocEntry" < :situacaoIsFilter)
+    AND (C."Code" IS NULL OR T0."DocEntry" < :semAcompanhamentoIsFilter)
+    AND (C."U_DataPromessa" <= :promessaVencidaAte OR T0."DocEntry" < :promessaVencidaIsFilter)
     AND (T0."BPLId"    = :filial   OR T0."BPLId"    < :filialIsFilter)
     AND (T0."SlpCode"  = :vendedor OR T0."SlpCode"  < :vendedorIsFilter)
     AND (T0."CardCode" = :cliente  OR T0."CardCode" < :clienteIsFilter)

--- a/src/main/resources/views/cobranca/cobranca-titulos-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-titulos-adiantamento.sql
@@ -32,4 +32,5 @@ WHERE
     AND (T0."BPLId"    = :filial   OR T0."BPLId"    < :filialIsFilter)
     AND (T0."SlpCode"  = :vendedor OR T0."SlpCode"  < :vendedorIsFilter)
     AND (T0."CardCode" = :cliente  OR T0."CardCode" < :clienteIsFilter)
+    AND T0."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
 ORDER BY P."DueDate", T0."DocNum"

--- a/src/main/resources/views/cobranca/cobranca-titulos-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-titulos-adiantamento.sql
@@ -1,0 +1,33 @@
+SELECT
+    T0."DocEntry", T0."DocNum",
+    VF."DocNum" AS "ContratoDocNum",
+    T0."BPLId", T0."BPLName", T0."CardCode", T0."CardName",
+    T0."DocDate", T0."DocTotal",
+    V."SlpCode", V."SlpName",
+    P."InstlmntID", P."InsTotal", P."PaidToDate", P."DueDate", P."Status" AS "StatusParcela",
+    C."U_Status", C."U_Cobrador", C."U_Acao", C."U_Situacao",
+    C."U_Ocorrencia", C."U_Observacao", C."U_DataAcao", C."U_DataPromessa"
+FROM ODPI T0
+    INNER JOIN DPI6 P ON P."DocEntry" = T0."DocEntry"
+    LEFT JOIN OSLP V ON V."SlpCode" = T0."SlpCode"
+    LEFT JOIN "@AR_CONTRATO_FUTURO" VF ON VF."DocEntry" = T0."U_venda_futura"
+    LEFT JOIN "@COB_TITULO" C
+         ON C."U_Tipo" = 'AD' AND C."U_DocEntry" = T0."DocEntry" AND C."U_InstlmntID" = P."InstlmntID"
+WHERE
+    T0."CANCELED" = 'N'
+    AND P."InsTotal" <> 0
+    AND (
+         (P."Status" = 'O'
+          AND P."DueDate" <= :data)
+      OR C."Code" IS NOT NULL
+    )
+    AND (P."Status"    = :statusParcela OR P."Status" < :statusParcelaIsFilter)
+    AND P."DueDate" >= :vencimentoDe
+    AND P."DueDate" <= :vencimentoAte
+    AND (C."U_Status"    = :status   OR T0."DocEntry" < :statusIsFilter)
+    AND (C."U_Cobrador"  = :cobrador OR T0."DocEntry" < :cobradorIsFilter)
+    AND (C."U_Situacao"  = :situacao OR T0."DocEntry" < :situacaoIsFilter)
+    AND (T0."BPLId"    = :filial   OR T0."BPLId"    < :filialIsFilter)
+    AND (T0."SlpCode"  = :vendedor OR T0."SlpCode"  < :vendedorIsFilter)
+    AND (T0."CardCode" = :cliente  OR T0."CardCode" < :clienteIsFilter)
+ORDER BY P."DueDate", T0."DocNum"

--- a/src/main/resources/views/cobranca/cobranca-titulos.sql
+++ b/src/main/resources/views/cobranca/cobranca-titulos.sql
@@ -30,4 +30,5 @@ WHERE
     AND (NS."BPLId"    = :filial   OR NS."BPLId"    < :filialIsFilter)
     AND (NS."SlpCode"  = :vendedor OR NS."SlpCode"  < :vendedorIsFilter)
     AND (NS."CardCode" = :cliente  OR NS."CardCode" < :clienteIsFilter)
+    AND NS."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
 ORDER BY P."DueDate", NS."DocNum"

--- a/src/main/resources/views/cobranca/cobranca-titulos.sql
+++ b/src/main/resources/views/cobranca/cobranca-titulos.sql
@@ -25,6 +25,8 @@ WHERE
     AND (C."U_Status"    = :status   OR NS."DocEntry" < :statusIsFilter)
     AND (C."U_Cobrador"  = :cobrador OR NS."DocEntry" < :cobradorIsFilter)
     AND (C."U_Situacao"  = :situacao OR NS."DocEntry" < :situacaoIsFilter)
+    AND (C."Code" IS NULL OR NS."DocEntry" < :semAcompanhamentoIsFilter)
+    AND (C."U_DataPromessa" <= :promessaVencidaAte OR NS."DocEntry" < :promessaVencidaIsFilter)
     AND (NS."BPLId"    = :filial   OR NS."BPLId"    < :filialIsFilter)
     AND (NS."SlpCode"  = :vendedor OR NS."SlpCode"  < :vendedorIsFilter)
     AND (NS."CardCode" = :cliente  OR NS."CardCode" < :clienteIsFilter)

--- a/src/main/resources/views/cobranca/cobranca-titulos.sql
+++ b/src/main/resources/views/cobranca/cobranca-titulos.sql
@@ -1,0 +1,31 @@
+SELECT
+    NS."DocEntry", NS."DocNum", NS."Serial", NS."Series",
+    NS."BPLId", NS."BPLName", NS."CardCode", NS."CardName",
+    NS."DocDate", NS."DocTotal",
+    V."SlpCode", V."SlpName",
+    P."InstlmntID", P."InsTotal", P."PaidToDate", P."DueDate", P."Status" AS "StatusParcela",
+    C."U_Status", C."U_Cobrador", C."U_Acao", C."U_Situacao",
+    C."U_Ocorrencia", C."U_Observacao", C."U_DataAcao", C."U_DataPromessa"
+FROM OINV NS
+    INNER JOIN INV6 P ON P."DocEntry" = NS."DocEntry"
+    LEFT JOIN OSLP V ON V."SlpCode" = NS."SlpCode"
+    LEFT JOIN "@COB_TITULO" C
+         ON C."U_Tipo" = 'NF' AND C."U_DocEntry" = NS."DocEntry" AND C."U_InstlmntID" = P."InstlmntID"
+WHERE
+    NS."CANCELED" = 'N'
+    AND P."InsTotal" <> 0
+    AND (
+         (P."Status" = 'O'
+          AND P."DueDate" <= :data)
+      OR C."Code" IS NOT NULL
+    )
+    AND (P."Status"    = :statusParcela OR P."Status" < :statusParcelaIsFilter)
+    AND P."DueDate" >= :vencimentoDe
+    AND P."DueDate" <= :vencimentoAte
+    AND (C."U_Status"    = :status   OR NS."DocEntry" < :statusIsFilter)
+    AND (C."U_Cobrador"  = :cobrador OR NS."DocEntry" < :cobradorIsFilter)
+    AND (C."U_Situacao"  = :situacao OR NS."DocEntry" < :situacaoIsFilter)
+    AND (NS."BPLId"    = :filial   OR NS."BPLId"    < :filialIsFilter)
+    AND (NS."SlpCode"  = :vendedor OR NS."SlpCode"  < :vendedorIsFilter)
+    AND (NS."CardCode" = :cliente  OR NS."CardCode" < :clienteIsFilter)
+ORDER BY P."DueDate", NS."DocNum"

--- a/src/main/resources/views/cobranca/cobranca-trabalhados-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-trabalhados-adiantamento.sql
@@ -1,0 +1,14 @@
+SELECT
+    H."U_Usuario",
+    count(DISTINCT H."Code") AS "Titulos"
+FROM "@COB_TITULO_L" H
+    INNER JOIN "@COB_TITULO" C ON C."Code" = H."Code"
+    INNER JOIN ODPI T0 ON T0."DocEntry" = C."U_DocEntry"
+WHERE
+    C."U_Tipo" = 'AD'
+    AND H."U_Data" >= :de
+    AND H."U_Data" <= :ate
+    AND (T0."BPLId"   = :filial   OR T0."BPLId"   < :filialIsFilter)
+    AND (T0."SlpCode" = :vendedor OR T0."SlpCode" < :vendedorIsFilter)
+GROUP BY
+    H."U_Usuario"

--- a/src/main/resources/views/cobranca/cobranca-trabalhados-adiantamento.sql
+++ b/src/main/resources/views/cobranca/cobranca-trabalhados-adiantamento.sql
@@ -10,5 +10,6 @@ WHERE
     AND H."U_Data" <= :ate
     AND (T0."BPLId"   = :filial   OR T0."BPLId"   < :filialIsFilter)
     AND (T0."SlpCode" = :vendedor OR T0."SlpCode" < :vendedorIsFilter)
+    AND T0."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
 GROUP BY
     H."U_Usuario"

--- a/src/main/resources/views/cobranca/cobranca-trabalhados.sql
+++ b/src/main/resources/views/cobranca/cobranca-trabalhados.sql
@@ -1,0 +1,14 @@
+SELECT
+    H."U_Usuario",
+    count(DISTINCT H."Code") AS "Titulos"
+FROM "@COB_TITULO_L" H
+    INNER JOIN "@COB_TITULO" C ON C."Code" = H."Code"
+    INNER JOIN OINV NS ON NS."DocEntry" = C."U_DocEntry"
+WHERE
+    C."U_Tipo" = 'NF'
+    AND H."U_Data" >= :de
+    AND H."U_Data" <= :ate
+    AND (NS."BPLId"   = :filial   OR NS."BPLId"   < :filialIsFilter)
+    AND (NS."SlpCode" = :vendedor OR NS."SlpCode" < :vendedorIsFilter)
+GROUP BY
+    H."U_Usuario"

--- a/src/main/resources/views/cobranca/cobranca-trabalhados.sql
+++ b/src/main/resources/views/cobranca/cobranca-trabalhados.sql
@@ -10,5 +10,6 @@ WHERE
     AND H."U_Data" <= :ate
     AND (NS."BPLId"   = :filial   OR NS."BPLId"   < :filialIsFilter)
     AND (NS."SlpCode" = :vendedor OR NS."SlpCode" < :vendedorIsFilter)
+    AND NS."CardCode" NOT IN (SELECT "DflCust" FROM OBPL WHERE "DflCust" IS NOT NULL)
 GROUP BY
     H."U_Usuario"

--- a/src/main/resources/views/titulos.sql
+++ b/src/main/resources/views/titulos.sql
@@ -17,7 +17,7 @@ FROM OINV NS
     INNER JOIN INV6 P ON P."DocEntry" = NS."DocEntry"
     INNER JOIN OSLP V ON V."SlpCode" = NS."SlpCode"
     LEFT JOIN "@COB_TITULO" C
-         ON C."U_DocEntry" = NS."DocEntry" AND C."U_InstlmntID" = P."InstlmntID"
+         ON C."U_Tipo" = 'NF' AND C."U_DocEntry" = NS."DocEntry" AND C."U_InstlmntID" = P."InstlmntID"
 WHERE
     NS."DocStatus" in ('O','D')
     AND NS."BPLId" in (2,4,11,17,18,12)

--- a/src/main/resources/views/titulos.sql
+++ b/src/main/resources/views/titulos.sql
@@ -11,11 +11,13 @@ SELECT
     P."DueDate",
     NS."DocTotal",
     P."PaidToDate",
-    P."U_StatusCobranca",
-    P."U_AgenteCobrador"
+    C."U_Status" AS "U_StatusCobranca",
+    C."U_Cobrador" AS "U_AgenteCobrador"
 FROM OINV NS
     INNER JOIN INV6 P ON P."DocEntry" = NS."DocEntry"
     INNER JOIN OSLP V ON V."SlpCode" = NS."SlpCode"
+    LEFT JOIN "@COB_TITULO" C
+         ON C."U_DocEntry" = NS."DocEntry" AND C."U_InstlmntID" = P."InstlmntID"
 WHERE
     NS."DocStatus" in ('O','D')
     AND NS."BPLId" in (2,4,11,17,18,12)

--- a/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaServiceTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaServiceTest.kt
@@ -317,6 +317,52 @@ class CobrancaConsultaServiceTest {
     }
 
     @Test
+    fun `adiantamento para de puxar pagina do SAP assim que ja tem o suficiente pra pagina pedida`() {
+        // Antes o adiantamento vinha de getAll: varria a view ate o fim em toda chamada, mesmo
+        // pra montar so a primeira tela. Com 20 linhas por pagina no SAP, isso era uma ida e
+        // volta a mais a cada 20 adiantamentos em aberto - custo fixo que crescia sozinho.
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos-adiantamento.sql"), any<List<Parameter>>()))
+            .thenReturn(
+                odataComAdiantamentos(
+                    adiantamento(diasAtraso = 30, contratoDocNum = null),
+                    adiantamento(diasAtraso = 20, contratoDocNum = null),
+                    proximaPagina = "pagina-2-do-adiantamento",
+                )
+            )
+
+        val resultado = service.listar(admin, pagina = 0, tamanhoPagina = 2)
+
+        assertEquals(2, resultado.size)
+        verify(sqlQueriesService, never()).nextLink("pagina-2-do-adiantamento")
+    }
+
+    @Test
+    fun `adiantamento continua puxando pagina nova enquanto faltar linha pra completar a pagina`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos-adiantamento.sql"), any<List<Parameter>>()))
+            .thenReturn(
+                odataComAdiantamentos(
+                    adiantamento(diasAtraso = 30, contratoDocNum = null),
+                    proximaPagina = "pagina-2-do-adiantamento",
+                )
+            )
+        whenever(sqlQueriesService.nextLink("pagina-2-do-adiantamento"))
+            .thenReturn(
+                odataComAdiantamentos(
+                    adiantamento(diasAtraso = 20, contratoDocNum = null),
+                    adiantamento(diasAtraso = 10, contratoDocNum = null),
+                )
+            )
+
+        val resultado = service.listar(admin, pagina = 0, tamanhoPagina = 3)
+
+        assertEquals(3, resultado.size)
+        // Mais antigo primeiro: o corte por pagina nao pode bagunçar a ordem do merge.
+        assertEquals(listOf(30L, 20L, 10L), resultado.map { it.DiasAtraso })
+    }
+
+    @Test
     fun `semAcompanhamento ligado e desligado manda so o IsFilter, porque nao tem valor a comparar`() {
         whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
 
@@ -406,9 +452,13 @@ class CobrancaConsultaServiceTest {
         return OData(backing)
     }
 
-    private fun odataComAdiantamentos(vararg adiantamentos: CobrancaAdiantamentoSap): OData {
+    private fun odataComAdiantamentos(
+        vararg adiantamentos: CobrancaAdiantamentoSap,
+        proximaPagina: String? = null,
+    ): OData {
         val backing = LinkedHashMap<String, Any?>()
         backing["value"] = adiantamentos.toList()
+        proximaPagina?.let { backing["odata.nextLink"] = it }
         return OData(backing)
     }
 }

--- a/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaServiceTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaServiceTest.kt
@@ -316,6 +316,47 @@ class CobrancaConsultaServiceTest {
         verify(sqlQueriesService, never()).execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())
     }
 
+    @Test
+    fun `semAcompanhamento ligado e desligado manda so o IsFilter, porque nao tem valor a comparar`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(admin, semAcompanhamento = true)
+
+        assertEquals(-1, capturarParametros()["semAcompanhamentoIsFilter"])
+    }
+
+    @Test
+    fun `sem semAcompanhamento o filtro fica desligado e o titulo acompanhado continua vindo`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(admin)
+
+        assertEquals(Int.MAX_VALUE, capturarParametros()["semAcompanhamentoIsFilter"])
+    }
+
+    @Test
+    fun `promessaVencidaAte informada vira data de corte no SQL`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(admin, promessaVencidaAte = LocalDate.of(2026, 8, 3))
+
+        val parametros = capturarParametros()
+        assertEquals("2026-08-03", parametros["promessaVencidaAte"])
+        assertEquals(-1, parametros["promessaVencidaIsFilter"])
+    }
+
+    @Test
+    fun `sem promessaVencidaAte o parametro de data ainda vai, mas o filtro esta desligado`() {
+        // A view sempre pede os dois parametros; quem desliga a condicao e o IsFilter.
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(admin, data = LocalDate.of(2026, 8, 3))
+
+        val parametros = capturarParametros()
+        assertEquals("2026-08-03", parametros["promessaVencidaAte"])
+        assertEquals(Int.MAX_VALUE, parametros["promessaVencidaIsFilter"])
+    }
+
     private fun capturarParametros(): Map<String, Any> {
         val captor = argumentCaptor<List<Parameter>>()
         verify(sqlQueriesService).execute(eq("cobranca-titulos.sql"), captor.capture())

--- a/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaServiceTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaConsultaServiceTest.kt
@@ -1,0 +1,373 @@
+package br.andrew.sap.services.cobranca
+
+import br.andrew.sap.infrastructure.odata.OData
+import br.andrew.sap.infrastructure.odata.Parameter
+import br.andrew.sap.model.authentication.User
+import br.andrew.sap.model.authentication.UserOriginEnum
+import br.andrew.sap.model.cobranca.CobrancaAdiantamentoSap
+import br.andrew.sap.model.cobranca.CobrancaTituloSap
+import br.andrew.sap.services.abstracts.SqlQueriesService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+class CobrancaConsultaServiceTest {
+
+    private val sqlQueriesService = mock<SqlQueriesService>()
+    private val service = CobrancaConsultaService(sqlQueriesService)
+
+    private val vendedor = User(
+        "60", "Fulano", UserOriginEnum.SalePerson, "fulano",
+        bussinesPlace = listOf(), roles = listOf("vendedor")
+    )
+    private val admin = User(
+        "1", "Admin", UserOriginEnum.EmployeesInfo, "admin",
+        bussinesPlace = listOf(), roles = listOf("admin")
+    )
+
+    @BeforeEach
+    fun semAdiantamentosPorPadrao() {
+        // A maioria dos testes aqui e sobre faturas; sem isso o mock devolve null pro
+        // getAll<CobrancaAdiantamentoSap> (viewName nao mockado) e todo teste quebra com NPE.
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos-adiantamento.sql"), any<List<Parameter>>()))
+            .thenReturn(odataComAdiantamentos())
+    }
+
+    @Test
+    fun `vendedor comum tem o filtro de vendedor forcado para o proprio codigo`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(vendedor)
+
+        val parametros = capturarParametros()
+        assertEquals(60, parametros["vendedor"])
+        assertEquals(-1, parametros["vendedorIsFilter"])
+    }
+
+    @Test
+    fun `admin sem escolher vendedor nao tem restricao de vendedor`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(admin)
+
+        val parametros = capturarParametros()
+        assertEquals(Int.MAX_VALUE, parametros["vendedorIsFilter"])
+    }
+
+    @Test
+    fun `filial e cliente informados viram filtro obrigatorio`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(admin, filial = 6, cliente = "CLI0007196")
+
+        val parametros = capturarParametros()
+        assertEquals(6, parametros["filial"])
+        assertEquals(-1, parametros["filialIsFilter"])
+        assertEquals("CLI0007196", parametros["cliente"])
+        assertEquals("", parametros["clienteIsFilter"])
+    }
+
+    @Test
+    fun `filial e cliente nao informados nao restringem`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(admin)
+
+        val parametros = capturarParametros()
+        assertEquals(Int.MAX_VALUE, parametros["filialIsFilter"])
+        assertEquals("~", parametros["clienteIsFilter"])
+    }
+
+    @Test
+    fun `diasAtrasoMin desloca o corte de vencimento no proprio SQL, sem parametro novo`() {
+        // Atraso >= N e o mesmo que DueDate <= hoje - N. Resolver isso no :data (que a view ja
+        // tem) evita que o laco de paginacao puxe pagina do SAP so pra descartar localmente.
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(admin, data = LocalDate.of(2026, 7, 28), diasAtrasoMin = 10)
+
+        assertEquals("2026-07-18", capturarParametros()["data"])
+    }
+
+    @Test
+    fun `sem diasAtrasoMin o corte de vencimento continua sendo a data pedida`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(admin, data = LocalDate.of(2026, 7, 28), diasAtrasoMin = null)
+
+        assertEquals("2026-07-28", capturarParametros()["data"])
+    }
+
+    @Test
+    fun `situacaoSap vira filtro de Status da parcela no SQL`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(admin, situacaoSap = "ABERTO")
+
+        val parametros = capturarParametros()
+        assertEquals("O", parametros["statusParcela"])
+        assertEquals("", parametros["statusParcelaIsFilter"])
+    }
+
+    @Test
+    fun `situacaoSap PAGO filtra a parcela fechada no SQL`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(admin, situacaoSap = "PAGO")
+
+        assertEquals("C", capturarParametros()["statusParcela"])
+    }
+
+    @Test
+    fun `sem situacaoSap o filtro de Status da parcela fica desligado`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(admin, situacaoSap = null)
+
+        val parametros = capturarParametros()
+        assertEquals("~", parametros["statusParcela"])
+        assertEquals("~", parametros["statusParcelaIsFilter"])
+    }
+
+    @Test
+    fun `intervalo de vencimento vai pro SQL com sentinela larga quando desligado`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(admin)
+
+        val parametros = capturarParametros()
+        assertEquals("1900-01-01", parametros["vencimentoDe"])
+        assertEquals("9999-12-31", parametros["vencimentoAte"])
+    }
+
+    @Test
+    fun `intervalo de vencimento informado vai pro SQL`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(
+            admin,
+            vencimentoDe = LocalDate.of(2026, 1, 1),
+            vencimentoAte = LocalDate.of(2026, 6, 30),
+        )
+
+        val parametros = capturarParametros()
+        assertEquals("2026-01-01", parametros["vencimentoDe"])
+        assertEquals("2026-06-30", parametros["vencimentoAte"])
+    }
+
+    @Test
+    fun `status cobrador e situacao viram filtro no SQL com escape em coluna nao-nula`() {
+        // Esses tres vem do LEFT JOIN da UDT (nulos pra titulo nunca acompanhado), entao o
+        // "desligado" nao pode ser testado na propria coluna - o escape e o DocEntry, que nunca
+        // e nulo. Ligado => -1 (escape falso, so a igualdade vale, e nulo nao casa com nada).
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(admin, status = "3 - SEM CONTATO", cobrador = "Marcela", situacao = "2 - A RECEBER")
+
+        val parametros = capturarParametros()
+        assertEquals("3 - SEM CONTATO", parametros["status"])
+        assertEquals(-1, parametros["statusIsFilter"])
+        assertEquals("Marcela", parametros["cobrador"])
+        assertEquals(-1, parametros["cobradorIsFilter"])
+        assertEquals("2 - A RECEBER", parametros["situacao"])
+        assertEquals(-1, parametros["situacaoIsFilter"])
+    }
+
+    @Test
+    fun `sem status cobrador e situacao o escape deixa passar tambem o titulo nunca acompanhado`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+
+        service.listar(admin)
+
+        val parametros = capturarParametros()
+        // Int.MAX_VALUE torna "DocEntry < :xIsFilter" verdadeiro pra toda linha - sem isso o
+        // titulo com U_Status nulo (a maioria) desapareceria da lista.
+        assertEquals(Int.MAX_VALUE, parametros["statusIsFilter"])
+        assertEquals(Int.MAX_VALUE, parametros["cobradorIsFilter"])
+        assertEquals(Int.MAX_VALUE, parametros["situacaoIsFilter"])
+    }
+
+    @Test
+    fun `filtros de dias em atraso e status sao aplicados depois da consulta ao SAP`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>()))
+            .thenReturn(
+                odataComTitulos(
+                    titulo(diasAtraso = 3, status = "8 - EM NEGOCIAÇÃO"),
+                    titulo(diasAtraso = 20, status = "3 - SEM CONTATO"),
+                )
+            )
+
+        val resultado = service.listar(admin, diasAtrasoMin = 10)
+
+        assertEquals(1, resultado.size)
+        assertEquals(20L, resultado.first().DiasAtraso)
+    }
+
+    @Test
+    fun `por padrao (situacaoSap ABERTO) titulo ja quitado no SAP nao aparece`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>()))
+            .thenReturn(
+                odataComTitulos(
+                    titulo(diasAtraso = 3, status = null, statusParcela = "C"), // quitado no SAP
+                    titulo(diasAtraso = 5, status = null, statusParcela = "O"), // em aberto
+                )
+            )
+
+        val resultado = service.listar(admin, situacaoSap = "ABERTO")
+
+        assertEquals(1, resultado.size)
+        assertEquals("ABERTO", resultado.first().SituacaoSap)
+    }
+
+    @Test
+    fun `situacaoSap null (Todos) traz tanto pago quanto aberto`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>()))
+            .thenReturn(
+                odataComTitulos(
+                    titulo(diasAtraso = 3, status = null, statusParcela = "C"),
+                    titulo(diasAtraso = 5, status = null, statusParcela = "O"),
+                )
+            )
+
+        val resultado = service.listar(admin, situacaoSap = null)
+
+        assertEquals(2, resultado.size)
+    }
+
+    @Test
+    fun `saldo negativo (rateio, adiantamento vinculado etc) nao classifica como pago se a parcela ainda esta aberta no SAP`() {
+        // Bug reportado: InsTotal - PaidToDate pode dar negativo (parcela aparentemente
+        // "paga a mais") mesmo com a parcela ainda 'O' (aberta) no SAP - a situacao tem que
+        // seguir o status oficial da parcela, nunca o saldo calculado.
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>()))
+            .thenReturn(
+                odataComTitulos(
+                    titulo(diasAtraso = 5, status = null, paidToDate = BigDecimal("110.00"), statusParcela = "O"),
+                )
+            )
+
+        val resultado = service.listar(admin, situacaoSap = null)
+
+        assertEquals(1, resultado.size)
+        assertEquals("ABERTO", resultado.first().SituacaoSap)
+    }
+
+    @Test
+    fun `adiantamento entra na lista e usa o numero do contrato de venda futura como NF`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())).thenReturn(odataVazia())
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos-adiantamento.sql"), any<List<Parameter>>()))
+            .thenReturn(odataComAdiantamentos(adiantamento(diasAtraso = 5, contratoDocNum = 777)))
+
+        val resultado = service.listar(admin)
+
+        assertEquals(1, resultado.size)
+        assertEquals("AD", resultado.first().Tipo)
+        assertEquals(777, resultado.first().DocNum)
+    }
+
+    @Test
+    fun `fatura e adiantamento com o mesmo DocEntry nao se confundem e saem ordenados por vencimento`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>()))
+            .thenReturn(odataComTitulos(titulo(diasAtraso = 5, status = null)))
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos-adiantamento.sql"), any<List<Parameter>>()))
+            .thenReturn(odataComAdiantamentos(adiantamento(diasAtraso = 10, contratoDocNum = null)))
+
+        val resultado = service.listar(admin)
+
+        assertEquals(2, resultado.size)
+        // O adiantamento (10 dias de atraso, vence antes) precisa vir primeiro.
+        assertEquals("AD", resultado[0].Tipo)
+        assertEquals("NF", resultado[1].Tipo)
+        assertEquals(1, resultado[0].DocEntry)
+        assertEquals(1, resultado[1].DocEntry)
+    }
+
+    @Test
+    fun `filtro tipo NF nao busca adiantamento`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos.sql"), any<List<Parameter>>()))
+            .thenReturn(odataComTitulos(titulo(diasAtraso = 5, status = null)))
+
+        val resultado = service.listar(admin, tipo = "NF")
+
+        assertEquals(1, resultado.size)
+        assertEquals("NF", resultado.first().Tipo)
+        verify(sqlQueriesService, never()).execute(eq("cobranca-titulos-adiantamento.sql"), any<List<Parameter>>())
+    }
+
+    @Test
+    fun `filtro tipo AD nao busca fatura`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-titulos-adiantamento.sql"), any<List<Parameter>>()))
+            .thenReturn(odataComAdiantamentos(adiantamento(diasAtraso = 5, contratoDocNum = null)))
+
+        val resultado = service.listar(admin, tipo = "AD")
+
+        assertEquals(1, resultado.size)
+        assertEquals("AD", resultado.first().Tipo)
+        verify(sqlQueriesService, never()).execute(eq("cobranca-titulos.sql"), any<List<Parameter>>())
+    }
+
+    private fun capturarParametros(): Map<String, Any> {
+        val captor = argumentCaptor<List<Parameter>>()
+        verify(sqlQueriesService).execute(eq("cobranca-titulos.sql"), captor.capture())
+        return captor.firstValue.associate { it.key to it.value }
+    }
+
+    private fun titulo(
+        diasAtraso: Int,
+        status: String?,
+        paidToDate: BigDecimal = BigDecimal.ZERO,
+        statusParcela: String = "O",
+    ): CobrancaTituloSap {
+        // DueDate relativo a hoje: DiasAtraso e calculado em Kotlin (CobrancaTituloSap.toDto),
+        // nao vem pronto do SAP - por isso o teste monta a data em vez de fixar o numero.
+        val dueDate = LocalDate.now().minusDays(diasAtraso.toLong()).format(DateTimeFormatter.BASIC_ISO_DATE)
+        return CobrancaTituloSap(
+            DocEntry = 1, DocNum = 1, Serial = "1", Series = 1,
+            BPLId = 6, BPLName = "Fazenda Serra Verde", CardCode = "CLI001", CardName = "Cliente Teste",
+            DocDate = "20260701", DocTotal = BigDecimal("100.00"),
+            SlpCode = 60, SlpName = "Vendedor Teste",
+            InstlmntID = 1, InsTotal = BigDecimal("100.00"), PaidToDate = paidToDate,
+            DueDate = dueDate, StatusParcela = statusParcela,
+            U_Status = status, U_Cobrador = null, U_Acao = null, U_Situacao = null,
+            U_Ocorrencia = null, U_Observacao = null, U_DataAcao = null, U_DataPromessa = null,
+        )
+    }
+
+    private fun adiantamento(diasAtraso: Int, contratoDocNum: Int?, statusParcela: String = "O"): CobrancaAdiantamentoSap {
+        val dueDate = LocalDate.now().minusDays(diasAtraso.toLong()).format(DateTimeFormatter.BASIC_ISO_DATE)
+        return CobrancaAdiantamentoSap(
+            DocEntry = 1, DocNumAdiantamento = 501, ContratoDocNum = contratoDocNum,
+            BPLId = 6, BPLName = "Fazenda Serra Verde", CardCode = "CLI001", CardName = "Cliente Teste",
+            DocDate = "20260701", DocTotal = BigDecimal("50.00"),
+            SlpCode = 60, SlpName = "Vendedor Teste",
+            InstlmntID = 1, InsTotal = BigDecimal("50.00"), PaidToDate = BigDecimal.ZERO,
+            DueDate = dueDate, StatusParcela = statusParcela,
+            U_Status = null, U_Cobrador = null, U_Acao = null, U_Situacao = null,
+            U_Ocorrencia = null, U_Observacao = null, U_DataAcao = null, U_DataPromessa = null,
+        )
+    }
+
+    private fun odataVazia() = odataComTitulos()
+
+    private fun odataComTitulos(vararg titulos: CobrancaTituloSap): OData {
+        val backing = LinkedHashMap<String, Any?>()
+        backing["value"] = titulos.toList()
+        return OData(backing)
+    }
+
+    private fun odataComAdiantamentos(vararg adiantamentos: CobrancaAdiantamentoSap): OData {
+        val backing = LinkedHashMap<String, Any?>()
+        backing["value"] = adiantamentos.toList()
+        return OData(backing)
+    }
+}

--- a/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaDashboardServiceTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaDashboardServiceTest.kt
@@ -1,0 +1,332 @@
+package br.andrew.sap.services.cobranca
+
+import br.andrew.sap.infrastructure.odata.OData
+import br.andrew.sap.infrastructure.odata.Parameter
+import br.andrew.sap.model.authentication.User
+import br.andrew.sap.model.authentication.UserOriginEnum
+import br.andrew.sap.model.cobranca.CobrancaAgregadoSap
+import br.andrew.sap.model.cobranca.CobrancaRecuperadoDiaSap
+import br.andrew.sap.model.cobranca.CobrancaRecuperadoSap
+import br.andrew.sap.model.cobranca.CobrancaTrabalhadosSap
+import br.andrew.sap.services.abstracts.SqlQueriesService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.math.BigDecimal
+import java.time.LocalDate
+
+class CobrancaDashboardServiceTest {
+
+    private val sqlQueriesService = mock<SqlQueriesService>()
+    private val service = CobrancaDashboardService(sqlQueriesService)
+
+    private val hoje = LocalDate.of(2026, 8, 3)
+    private val de = LocalDate.of(2026, 8, 1)
+    private val ate = LocalDate.of(2026, 8, 3)
+
+    private val vendedor = User(
+        "60", "Fulano", UserOriginEnum.SalePerson, "fulano",
+        bussinesPlace = listOf(), roles = listOf("vendedor")
+    )
+    private val admin = User(
+        "1", "Admin", UserOriginEnum.EmployeesInfo, "admin",
+        bussinesPlace = listOf(), roles = listOf("admin")
+    )
+
+    // getAll e inline: ele expande pra execute(...)!!.tryGetNextValues(), entao quem e
+    // mockado aqui e o execute. E como tem "!!", qualquer view nao mockada estoura NPE -
+    // por isso todas as dez comecam vazias e cada teste sobrescreve so a que lhe interessa.
+    @BeforeEach
+    fun todasAsViewsVaziasPorPadrao() {
+        listOf(
+            "cobranca-carteira.sql", "cobranca-carteira-adiantamento.sql",
+            "cobranca-recuperado.sql", "cobranca-recuperado-adiantamento.sql",
+            "cobranca-recuperado-diario.sql", "cobranca-recuperado-diario-adiantamento.sql",
+            "cobranca-sem-acao.sql", "cobranca-sem-acao-adiantamento.sql",
+            "cobranca-promessa-vencida.sql", "cobranca-promessa-vencida-adiantamento.sql",
+            "cobranca-trabalhados.sql", "cobranca-trabalhados-adiantamento.sql",
+        ).forEach { view ->
+            whenever(sqlQueriesService.execute(eq(view), any<List<Parameter>>())).thenReturn(odata())
+        }
+    }
+
+    @Test
+    fun `as quatro faixas de aging viram janelas de vencimento sem buraco e sem sobreposicao`() {
+        // Faixa de atraso nao sai de CASE WHEN (o parser do SQLQueries nao aceita): cada
+        // faixa e uma janela de DueDate. Se as bordas nao encostarem exatamente, titulo
+        // desaparece do total ou e contado duas vezes - e o total do dashboard mente.
+        service.resumo(admin, de = de, ate = ate, hoje = hoje)
+
+        val janelas = janelasDeVencimento()
+        assertEquals(4, janelas.size)
+        // Comeca em 1 dia de atraso: parcela que vence hoje (2026-08-03) nao esta em atraso, e a
+        // tela de titulos ja exclui essas por padrao - com 0 aqui, clicar na faixa abriria uma
+        // lista menor que o card.
+        assertEquals("2026-07-04" to "2026-08-02", janelas[0])
+        assertEquals("2026-06-04" to "2026-07-03", janelas[1])
+        assertEquals("2026-05-05" to "2026-06-03", janelas[2])
+        assertEquals("1900-01-01" to "2026-05-04", janelas[3])
+    }
+
+    @Test
+    fun `periodo anterior tem a mesma duracao e termina um dia antes do periodo pedido`() {
+        // Sem isso o delta compararia janelas de tamanhos diferentes - um mes cheio contra tres
+        // dias - e a variacao percentual viraria ficcao.
+        service.resumo(admin, de = LocalDate.of(2026, 8, 1), ate = LocalDate.of(2026, 8, 31), hoje = hoje)
+
+        val janelas = janelasDeRecuperado()
+        assertEquals(2, janelas.size)
+        assertEquals("2026-08-01" to "2026-08-31", janelas[0])
+        // 31 dias contra 31 dias (1 a 31 de julho), terminando na vespera de 1/ago.
+        assertEquals("2026-07-01" to "2026-07-31", janelas[1])
+    }
+
+    @Test
+    fun `periodo anterior de um dia so tambem tem um dia so`() {
+        service.resumo(admin, de = LocalDate.of(2026, 8, 3), ate = LocalDate.of(2026, 8, 3), hoje = hoje)
+
+        assertEquals("2026-08-02" to "2026-08-02", janelasDeRecuperado()[1])
+    }
+
+    @Test
+    fun `resumo devolve as datas da janela anterior pra tela poder rotular a comparacao`() {
+        val resumo = service.resumo(admin, de = LocalDate.of(2026, 8, 1), ate = LocalDate.of(2026, 8, 31), hoje = hoje)
+
+        assertEquals("2026-07-01", resumo.DeAnterior)
+        assertEquals("2026-07-31", resumo.AteAnterior)
+    }
+
+    @Test
+    fun `recuperado do periodo e do anterior nao se misturam`() {
+        // As duas chamadas usam a MESMA view, so mudando :de/:ate - se o Kotlin trocasse os
+        // resultados, o delta apareceria invertido e ninguem notaria.
+        val captor = argumentCaptor<List<Parameter>>()
+        whenever(sqlQueriesService.execute(eq("cobranca-recuperado.sql"), captor.capture()))
+            .thenReturn(odata(recuperado(cobrador = "MARCELA", valor = "1000.00", documentos = 2)))
+            .thenReturn(odata(recuperado(cobrador = "MARCELA", valor = "400.00", documentos = 1)))
+
+        val resumo = service.resumo(admin, de = de, ate = ate, hoje = hoje)
+
+        assertEquals(BigDecimal("1000.00"), resumo.Recuperado)
+        assertEquals(BigDecimal("400.00"), resumo.RecuperadoAnterior)
+    }
+
+    @Test
+    fun `faixa aberta usa piso largo em vez de omitir o parametro`() {
+        service.resumo(admin, de = de, ate = ate, hoje = hoje)
+
+        // A view recebe sempre vencimentoDe e vencimentoAte; a faixa "+90" nao pode
+        // simplesmente nao mandar o piso, senao o parametro fica sem valor no SAP.
+        assertEquals("1900-01-01", janelasDeVencimento().last().first)
+    }
+
+    @Test
+    fun `saldo desconta o pago e sobrevive a PaidToDate ausente`() {
+        // O SQL nao subtrai (sem IFNULL, um PaidToDate nulo envenenaria a soma do grupo
+        // inteiro): a view devolve Total e Pago separados e a conta acontece em Kotlin.
+        whenever(sqlQueriesService.execute(eq("cobranca-carteira.sql"), any<List<Parameter>>()))
+            .thenReturn(odata(agregado(total = "100.00", pago = "30.00", parcelas = 2)))
+        whenever(sqlQueriesService.execute(eq("cobranca-carteira-adiantamento.sql"), any<List<Parameter>>()))
+            .thenReturn(odata(agregado(total = "50.00", pago = null, parcelas = 1)))
+
+        val resumo = service.resumo(admin, de = de, ate = ate, hoje = hoje)
+
+        // 4 faixas x (100-30) + 4 faixas x (50-0) = 4 x 120
+        assertEquals(BigDecimal("480.00"), resumo.CarteiraSaldo)
+        assertEquals(12, resumo.CarteiraParcelas)
+    }
+
+    @Test
+    fun `nota fiscal e adiantamento somam no mesmo total`() {
+        // UNION nao passa no parser do SQLQueries, entao sao views separadas - se o Kotlin
+        // esquecer de somar uma delas o total do dashboard nao fecha com a tela de titulos.
+        whenever(sqlQueriesService.execute(eq("cobranca-recuperado.sql"), any<List<Parameter>>()))
+            .thenReturn(odata(recuperado(cobrador = "MARCELA", valor = "1000.00", documentos = 3)))
+        whenever(sqlQueriesService.execute(eq("cobranca-recuperado-adiantamento.sql"), any<List<Parameter>>()))
+            .thenReturn(odata(recuperado(cobrador = "MARCELA", valor = "250.00", documentos = 1)))
+
+        val resumo = service.resumo(admin, de = de, ate = ate, hoje = hoje)
+
+        assertEquals(BigDecimal("1250.00"), resumo.Recuperado)
+        assertEquals(4, resumo.RecuperadoDocumentos)
+        assertEquals(1, resumo.PorCobrador.size)
+        assertEquals(BigDecimal("1250.00"), resumo.PorCobrador.first().Recuperado)
+    }
+
+    @Test
+    fun `vendedor comum tem o escopo forcado para o proprio codigo`() {
+        service.resumo(vendedor, vendedor = 99, de = de, ate = ate, hoje = hoje)
+
+        val parametros = primeirosParametros("cobranca-carteira.sql")
+        assertEquals(60, parametros["vendedor"])
+        assertEquals(-1, parametros["vendedorIsFilter"])
+    }
+
+    @Test
+    fun `admin sem escolher vendedor nao restringe`() {
+        service.resumo(admin, de = de, ate = ate, hoje = hoje)
+
+        val parametros = primeirosParametros("cobranca-carteira.sql")
+        assertEquals(Int.MAX_VALUE, parametros["vendedorIsFilter"])
+        assertEquals(Int.MAX_VALUE, parametros["filialIsFilter"])
+    }
+
+    @Test
+    fun `porCobrador junta esforco e resultado, e nao perde quem trabalhou sem recuperar`() {
+        // O caso que importa pro gestor: distinguir "trabalhou e nao recuperou" de "nao
+        // trabalhou". Se a juncao fosse so pelas linhas de recuperado, a LAURA sumiria.
+        whenever(sqlQueriesService.execute(eq("cobranca-recuperado.sql"), any<List<Parameter>>()))
+            .thenReturn(odata(recuperado(cobrador = "MARCELA", valor = "800.00", documentos = 2)))
+        whenever(sqlQueriesService.execute(eq("cobranca-trabalhados.sql"), any<List<Parameter>>()))
+            .thenReturn(odata(trabalhados("MARCELA", 5), trabalhados("LAURA", 7)))
+
+        val porCobrador = service.resumo(admin, de = de, ate = ate, hoje = hoje).PorCobrador
+
+        assertEquals(listOf("MARCELA", "LAURA"), porCobrador.map { it.Cobrador })
+        assertEquals(5, porCobrador.first { it.Cobrador == "MARCELA" }.TitulosTrabalhados)
+        val laura = porCobrador.first { it.Cobrador == "LAURA" }
+        assertEquals(7, laura.TitulosTrabalhados)
+        assertEquals(BigDecimal.ZERO, laura.Recuperado)
+    }
+
+    @Test
+    fun `cobrador e status ausentes ganham rotulo em vez de virar chave vazia`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-carteira.sql"), any<List<Parameter>>()))
+            .thenReturn(odata(agregado(total = "10.00", pago = "0.00", parcelas = 1, status = null)))
+        whenever(sqlQueriesService.execute(eq("cobranca-recuperado.sql"), any<List<Parameter>>()))
+            .thenReturn(odata(recuperado(cobrador = null, valor = "5.00", documentos = 1)))
+
+        val resumo = service.resumo(admin, de = de, ate = ate, hoje = hoje)
+
+        assertEquals("Sem acompanhamento", resumo.PorStatus.first().Status)
+        assertEquals("Sem cobrador", resumo.PorCobrador.first().Cobrador)
+    }
+
+    @Test
+    fun `evolucao devolve um ponto por mes, inclusive mes sem pagamento`() {
+        // Mes zerado tem que aparecer: buraco na serie faz o leitor achar que o mes nao
+        // foi medido, em vez de entender que nao entrou nada.
+        whenever(sqlQueriesService.execute(eq("cobranca-recuperado-diario.sql"), any<List<Parameter>>()))
+            .thenReturn(odata(dia("20260715", "100.00"), dia("20260720", "50.00"), dia("20260802", "700.00")))
+
+        val meses = service.evolucao(admin, meses = 3, hoje = hoje)
+
+        assertEquals(listOf("2026-06", "2026-07", "2026-08"), meses.map { it.Mes })
+        assertEquals(listOf("jun/26", "jul/26", "ago/26"), meses.map { it.Rotulo })
+        assertEquals(BigDecimal.ZERO, meses[0].Recuperado)
+        assertEquals(BigDecimal("150.00"), meses[1].Recuperado)
+        assertEquals(BigDecimal("700.00"), meses[2].Recuperado)
+    }
+
+    @Test
+    fun `evolucao busca a janela inteira numa consulta so, nao uma por mes`() {
+        service.evolucao(admin, meses = 6, hoje = hoje)
+
+        verify(sqlQueriesService, times(1))
+            .execute(eq("cobranca-recuperado-diario.sql"), any<List<Parameter>>())
+        val parametros = primeirosParametros("cobranca-recuperado-diario.sql")
+        assertEquals("2026-03-01", parametros["de"])
+        assertEquals("2026-08-03", parametros["ate"])
+    }
+
+    @Test
+    fun `evolucao limita o numero de meses pedido`() {
+        service.evolucao(admin, meses = 999, hoje = hoje)
+
+        val parametros = primeirosParametros("cobranca-recuperado-diario.sql")
+        // 24 meses e o teto: sem limite um ?meses=9999 viraria uma varredura da base inteira.
+        assertEquals("2024-09-01", parametros["de"])
+    }
+
+    @Test
+    fun `promessa vencida e sem acao usam a data de hoje, nao o periodo pedido`() {
+        // Carteira, promessa e "sem acao" sao foto de HOJE; recuperado e trabalhado sao do
+        // periodo. Trocar um pelo outro faria o card de SLA responder pelo mes passado.
+        service.resumo(admin, de = LocalDate.of(2026, 1, 1), ate = LocalDate.of(2026, 1, 31), hoje = hoje)
+
+        assertEquals("2026-08-03", primeirosParametros("cobranca-sem-acao.sql")["data"])
+        assertEquals("2026-08-03", primeirosParametros("cobranca-promessa-vencida.sql")["data"])
+        assertEquals("2026-01-01", primeirosParametros("cobranca-recuperado.sql")["de"])
+        assertEquals("2026-01-31", primeirosParametros("cobranca-recuperado.sql")["ate"])
+    }
+
+    @Test
+    fun `filial por saldo vem ordenada da maior para a menor`() {
+        whenever(sqlQueriesService.execute(eq("cobranca-carteira.sql"), any<List<Parameter>>()))
+            .thenReturn(
+                odata(
+                    agregado(total = "10.00", pago = "0.00", parcelas = 1, bplId = 2, bplName = "Vilhena"),
+                    agregado(total = "90.00", pago = "0.00", parcelas = 1, bplId = 6, bplName = "Serra Verde"),
+                )
+            )
+
+        val porFilial = service.resumo(admin, de = de, ate = ate, hoje = hoje).PorFilial
+
+        assertEquals(listOf(6, 2), porFilial.map { it.BPLId })
+        assertTrue(porFilial.first().Saldo > porFilial.last().Saldo)
+    }
+
+    private fun janelasDeVencimento(): List<Pair<String, String>> {
+        val captor = argumentCaptor<List<Parameter>>()
+        verify(sqlQueriesService, times(4)).execute(eq("cobranca-carteira.sql"), captor.capture())
+        return captor.allValues.map { parametros ->
+            val mapa = parametros.associate { it.key to it.value }
+            mapa["vencimentoDe"].toString() to mapa["vencimentoAte"].toString()
+        }
+    }
+
+    // As duas janelas (periodo pedido e anterior) na ordem em que foram pedidas ao SAP.
+    private fun janelasDeRecuperado(): List<Pair<String, String>> {
+        val captor = argumentCaptor<List<Parameter>>()
+        verify(sqlQueriesService, times(2)).execute(eq("cobranca-recuperado.sql"), captor.capture())
+        return captor.allValues.map { parametros ->
+            val mapa = parametros.associate { it.key to it.value }
+            mapa["de"].toString() to mapa["ate"].toString()
+        }
+    }
+
+    private fun primeirosParametros(view: String): Map<String, Any> {
+        val captor = argumentCaptor<List<Parameter>>()
+        verify(sqlQueriesService, org.mockito.kotlin.atLeastOnce()).execute(eq(view), captor.capture())
+        return captor.firstValue.associate { it.key to it.value }
+    }
+
+    private fun agregado(
+        total: String?,
+        pago: String?,
+        parcelas: Int,
+        status: String? = "1 - NÃO INICIADO",
+        cobrador: String? = null,
+        bplId: Int? = 6,
+        bplName: String? = "Fazenda Serra Verde",
+    ) = CobrancaAgregadoSap(
+        BPLId = bplId, BPLName = bplName,
+        U_Status = status, U_Cobrador = cobrador,
+        Total = total?.let { BigDecimal(it) }, Pago = pago?.let { BigDecimal(it) },
+        Parcelas = parcelas,
+    )
+
+    private fun recuperado(cobrador: String?, valor: String, documentos: Int) = CobrancaRecuperadoSap(
+        BPLId = 6, BPLName = "Fazenda Serra Verde", U_Cobrador = cobrador,
+        Recuperado = BigDecimal(valor), Documentos = documentos,
+    )
+
+    private fun trabalhados(usuario: String, titulos: Int) = CobrancaTrabalhadosSap(usuario, titulos)
+
+    private fun dia(docDate: String, valor: String) =
+        CobrancaRecuperadoDiaSap(DocDate = docDate, Recuperado = BigDecimal(valor), Documentos = 1)
+
+    private fun odata(vararg linhas: Any): OData {
+        val backing = LinkedHashMap<String, Any?>()
+        backing["value"] = linhas.toList()
+        return OData(backing)
+    }
+}

--- a/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaDashboardServiceTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaDashboardServiceTest.kt
@@ -215,7 +215,13 @@ class CobrancaDashboardServiceTest {
         // Mes zerado tem que aparecer: buraco na serie faz o leitor achar que o mes nao
         // foi medido, em vez de entender que nao entrou nada.
         whenever(sqlQueriesService.execute(eq("cobranca-recuperado-diario.sql"), any<List<Parameter>>()))
-            .thenReturn(odata(dia("20260715", "100.00"), dia("20260720", "50.00"), dia("20260802", "700.00")))
+            .thenReturn(
+                odata(
+                    dia("20260715", "100.00", docEntry = 500),
+                    dia("20260720", "50.00", docEntry = 501),
+                    dia("20260802", "700.00", docEntry = 502),
+                )
+            )
 
         val meses = service.evolucao(admin, meses = 3, hoje = hoje)
 
@@ -224,6 +230,19 @@ class CobrancaDashboardServiceTest {
         assertEquals(BigDecimal.ZERO, meses[0].Recuperado)
         assertEquals(BigDecimal("150.00"), meses[1].Recuperado)
         assertEquals(BigDecimal("700.00"), meses[2].Recuperado)
+    }
+
+    @Test
+    fun `evolucao conta o mesmo documento uma vez so, mesmo pago em dois dias do mes`() {
+        // Achado do bot: cada linha diaria ja vinha com "Documentos" contado por dia; somar
+        // essas linhas no mes duplicava a nota que recebeu pagamento parcial em dois dias.
+        whenever(sqlQueriesService.execute(eq("cobranca-recuperado-diario.sql"), any<List<Parameter>>()))
+            .thenReturn(odata(dia("20260801", "60.00", docEntry = 500), dia("20260803", "40.00", docEntry = 500)))
+
+        val meses = service.evolucao(admin, meses = 1, hoje = hoje)
+
+        assertEquals(BigDecimal("100.00"), meses.single().Recuperado)
+        assertEquals(1, meses.single().Documentos)
     }
 
     @Test
@@ -321,8 +340,8 @@ class CobrancaDashboardServiceTest {
 
     private fun trabalhados(usuario: String, titulos: Int) = CobrancaTrabalhadosSap(usuario, titulos)
 
-    private fun dia(docDate: String, valor: String) =
-        CobrancaRecuperadoDiaSap(DocDate = docDate, Recuperado = BigDecimal(valor), Documentos = 1)
+    private fun dia(docDate: String, valor: String, docEntry: Int) =
+        CobrancaRecuperadoDiaSap(DocDate = docDate, Recuperado = BigDecimal(valor), DocEntry = docEntry)
 
     private fun odata(vararg linhas: Any): OData {
         val backing = LinkedHashMap<String, Any?>()

--- a/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaDashboardSqlTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaDashboardSqlTest.kt
@@ -1,0 +1,181 @@
+package br.andrew.sap.services.cobranca
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+class CobrancaDashboardSqlTest {
+
+    private val pasta = Path.of("src/main/resources/views/cobranca")
+
+    private val views = listOf(
+        "cobranca-carteira.sql", "cobranca-carteira-adiantamento.sql",
+        "cobranca-recuperado.sql", "cobranca-recuperado-adiantamento.sql",
+        "cobranca-recuperado-diario.sql", "cobranca-recuperado-diario-adiantamento.sql",
+        "cobranca-sem-acao.sql", "cobranca-sem-acao-adiantamento.sql",
+        "cobranca-promessa-vencida.sql", "cobranca-promessa-vencida-adiantamento.sql",
+        "cobranca-trabalhados.sql", "cobranca-trabalhados-adiantamento.sql",
+    ).associateWith { Files.readString(pasta.resolve(it)) }
+
+    @Test
+    fun `nenhuma view do dashboard usa construcao sem precedente no parser do SQLQueries`() {
+        // IFNULL/CASE WHEN/DAYS_BETWEEN ja quebraram o provisionamento em producao
+        // ("mismatched input '.' expecting FROM") e nao aparecem em nenhuma das 46 views do
+        // projeto. MIN/MAX tambem nao tem precedente - por isso a serie mensal agrupa por
+        // data crua e monta o mes em Kotlin em vez de pedir o menor/maior no SQL.
+        val proibidas = listOf(
+            "CASE", "IFNULL", "COALESCE", "DAYS_BETWEEN", "CURRENT_DATE",
+            "CAST(", "UNION", "MIN(", "MAX(",
+        )
+        views.forEach { (nome, sql) ->
+            val maiuscula = sql.uppercase()
+            proibidas.forEach { proibida ->
+                assertFalse(
+                    maiuscula.contains(proibida),
+                    "$nome usa '$proibida', que nao tem precedente nas views do projeto"
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `nenhuma view do dashboard tem comentario SQL`() {
+        // Comentario com "--" ja foi removido a mao de view deste projeto; nao arriscar.
+        views.forEach { (nome, sql) ->
+            assertFalse(sql.contains("--"), "$nome tem comentario SQL")
+        }
+    }
+
+    @Test
+    fun `carteira devolve Total e Pago separados, sem subtrair no SQL`() {
+        // Sem IFNULL, um PaidToDate nulo envenenaria sum(InsTotal - PaidToDate) do grupo
+        // inteiro. As duas somas voltam cruas e o saldo e calculado em Kotlin.
+        listOf("cobranca-carteira.sql", "cobranca-carteira-adiantamento.sql").forEach { nome ->
+            val sql = views.getValue(nome)
+            assertTrue(sql.contains("sum(P.\"InsTotal\")   AS \"Total\""), nome)
+            assertTrue(sql.contains("sum(P.\"PaidToDate\") AS \"Pago\""), nome)
+            assertFalse(sql.contains("InsTotal\" -"), "$nome nao deve subtrair dentro do SQL")
+        }
+    }
+
+    @Test
+    fun `carteira conta parcela, nao documento distinto`() {
+        // A carteira e somada nas QUATRO faixas de aging. Com count(DISTINCT DocEntry),
+        // uma nota com parcelas em faixas diferentes seria contada uma vez em cada faixa e
+        // o total do card sairia inflado. Uma linha do join OINV x INV6 e uma parcela,
+        // entao count da coluna da parcela e a contagem certa - e parcela e a unidade que o
+        // time usa (as 213 linhas da planilha eram parcelas, nao notas).
+        listOf(
+            "cobranca-carteira.sql", "cobranca-carteira-adiantamento.sql",
+            "cobranca-sem-acao.sql", "cobranca-sem-acao-adiantamento.sql",
+            "cobranca-promessa-vencida.sql", "cobranca-promessa-vencida-adiantamento.sql",
+        ).forEach { nome ->
+            val sql = views.getValue(nome)
+            assertTrue(sql.contains("count(P.\"InstlmntID\") AS \"Parcelas\""), nome)
+            assertFalse(
+                sql.contains("count(DISTINCT"),
+                "$nome nao pode contar documento distinto: o total soma as quatro faixas"
+            )
+        }
+    }
+
+    @Test
+    fun `recuperado so conta pagamento que veio DEPOIS de existir acao de cobranca`() {
+        // Este EXISTS e o que separa "a cobranca trouxe de volta" de "o cliente pagou
+        // sozinho". Sem ele o dashboard credita ao time todo pagamento de titulo que por
+        // acaso tem registro - ou seja, mente a favor de quem esta sendo medido.
+        listOf(
+            "cobranca-recuperado.sql", "cobranca-recuperado-adiantamento.sql",
+            "cobranca-recuperado-diario.sql", "cobranca-recuperado-diario-adiantamento.sql",
+        ).forEach { nome ->
+            assertTrue(
+                views.getValue(nome).contains(
+                    "EXISTS(SELECT 1 FROM \"@COB_TITULO_L\" H WHERE H.\"Code\" = C.\"Code\" AND H.\"U_Data\" <= r.\"DocDate\")"
+                ),
+                "$nome perdeu o EXISTS que exige acao registrada antes do pagamento"
+            )
+        }
+    }
+
+    @Test
+    fun `recuperado liga pagamento a parcela pelo mesmo join de parcelas-pagas`() {
+        // RCT2."DocNum" e o DocEntry do ORCT (nao o numero do documento) - o join invertido
+        // silenciosamente casaria linhas erradas. O precedente e views/parcelas-pagas.sql.
+        listOf("cobranca-recuperado.sql", "cobranca-recuperado-adiantamento.sql").forEach { nome ->
+            val sql = views.getValue(nome)
+            assertTrue(sql.contains("INNER JOIN ORCT r ON r.\"DocEntry\" = l.\"DocNum\""), nome)
+            assertTrue(sql.contains("C.\"U_InstlmntID\" = l.\"InstId\""), nome)
+            assertTrue(sql.contains("(r.\"Canceled\" = 'N' OR r.\"Canceled\" IS NULL)"), nome)
+        }
+    }
+
+    @Test
+    fun `cada par de view usa o InvType e o Tipo certo pra nao misturar nota com adiantamento`() {
+        // ODPI e OINV tem contadores de DocEntry independentes (ObjType 13 x 203); sem o
+        // par InvType/U_Tipo, pagamento de adiantamento entraria como recuperacao de nota.
+        assertTrue(views.getValue("cobranca-recuperado.sql").contains("l.\"InvType\" = 13"))
+        assertTrue(views.getValue("cobranca-recuperado.sql").contains("C.\"U_Tipo\" = 'NF'"))
+        assertTrue(views.getValue("cobranca-recuperado-adiantamento.sql").contains("l.\"InvType\" = 203"))
+        assertTrue(views.getValue("cobranca-recuperado-adiantamento.sql").contains("C.\"U_Tipo\" = 'AD'"))
+    }
+
+    @Test
+    fun `sem-acao procura ausencia de registro na UDT, nao status vazio`() {
+        // "Ninguem tocou" e C."Code" IS NULL (nao existe registro). Um titulo COM registro
+        // mas sem status preenchido e outra coisa - e ja aparece no grupo de status.
+        listOf("cobranca-sem-acao.sql", "cobranca-sem-acao-adiantamento.sql").forEach { nome ->
+            val sql = views.getValue(nome)
+            assertTrue(sql.contains("LEFT JOIN \"@COB_TITULO\" C"), "$nome precisa de LEFT JOIN")
+            assertTrue(sql.contains("C.\"Code\" IS NULL"), nome)
+        }
+    }
+
+    @Test
+    fun `promessa vencida exige parcela ainda aberta`() {
+        // Promessa vencida so e quebra de SLA se o titulo continua em aberto; se pagou
+        // depois da data prometida, a promessa foi cumprida com atraso, nao quebrada.
+        listOf("cobranca-promessa-vencida.sql", "cobranca-promessa-vencida-adiantamento.sql").forEach { nome ->
+            val sql = views.getValue(nome)
+            assertTrue(sql.contains("P.\"Status\" = 'O'"), nome)
+            assertTrue(sql.contains("C.\"U_DataPromessa\" <= :data"), nome)
+            assertTrue(sql.contains("INNER JOIN \"@COB_TITULO\" C"), "$nome nao pode ser LEFT JOIN")
+        }
+    }
+
+    @Test
+    fun `trabalhados conta titulo distinto, nao linha de historico`() {
+        // count(DISTINCT Code) = titulos tocados. Cinco ligacoes no mesmo titulo nao e
+        // cinco vezes o trabalho de cinco titulos - e count(DISTINCT ...) e a unica forma
+        // de count com precedente no projeto (carregamento/peso-ordem-carregamento.sql).
+        listOf("cobranca-trabalhados.sql", "cobranca-trabalhados-adiantamento.sql").forEach { nome ->
+            val sql = views.getValue(nome)
+            assertTrue(sql.contains("count(DISTINCT H.\"Code\") AS \"Titulos\""), nome)
+            assertTrue(sql.contains("H.\"U_Data\" >= :de"), nome)
+            assertTrue(sql.contains("H.\"U_Data\" <= :ate"), nome)
+        }
+    }
+
+    @Test
+    fun `toda view do dashboard aceita o filtro opcional de filial e vendedor`() {
+        // Filtro dentro de card de grafico e anti-padrao: a tela tem UMA linha de filtro e
+        // todos os numeros obedecem o mesmo recorte. Se uma view ignorasse filial, um card
+        // mostraria a empresa inteira ao lado de outro filtrado - e ninguem notaria.
+        views.forEach { (nome, sql) ->
+            assertTrue(sql.contains(":filialIsFilter"), "$nome nao filtra filial")
+            assertTrue(sql.contains(":vendedorIsFilter"), "$nome nao filtra vendedor")
+        }
+    }
+
+    @Test
+    fun `carteira e sem-acao olham so parcela aberta`() {
+        listOf(
+            "cobranca-carteira.sql", "cobranca-carteira-adiantamento.sql",
+            "cobranca-sem-acao.sql", "cobranca-sem-acao-adiantamento.sql",
+        ).forEach { nome ->
+            assertTrue(views.getValue(nome).contains("P.\"Status\" = 'O'"), nome)
+            assertTrue(views.getValue(nome).contains("\"CANCELED\" = 'N'"), nome)
+        }
+    }
+}

--- a/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaDashboardSqlTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaDashboardSqlTest.kt
@@ -82,19 +82,39 @@ class CobrancaDashboardSqlTest {
     }
 
     @Test
-    fun `recuperado so conta pagamento que veio DEPOIS de existir acao de cobranca`() {
+    fun `recuperado diario so conta pagamento que veio DEPOIS de existir acao de cobranca`() {
         // Este EXISTS e o que separa "a cobranca trouxe de volta" de "o cliente pagou
         // sozinho". Sem ele o dashboard credita ao time todo pagamento de titulo que por
         // acaso tem registro - ou seja, mente a favor de quem esta sendo medido.
-        listOf(
-            "cobranca-recuperado.sql", "cobranca-recuperado-adiantamento.sql",
-            "cobranca-recuperado-diario.sql", "cobranca-recuperado-diario-adiantamento.sql",
-        ).forEach { nome ->
+        listOf("cobranca-recuperado-diario.sql", "cobranca-recuperado-diario-adiantamento.sql").forEach { nome ->
             assertTrue(
                 views.getValue(nome).contains(
                     "EXISTS(SELECT 1 FROM \"@COB_TITULO_L\" H WHERE H.\"Code\" = C.\"Code\" AND H.\"U_Data\" <= r.\"DocDate\")"
                 ),
                 "$nome perdeu o EXISTS que exige acao registrada antes do pagamento"
+            )
+        }
+    }
+
+    @Test
+    fun `recuperado por cobrador so conta pagamento que veio DEPOIS de existir acao, e atribui ao cobrador daquela acao`() {
+        // O INNER JOIN em H (em vez de C) exige uma acao registrada antes do pagamento -
+        // sem nenhuma linha de historico anterior, o join nao produz linha nenhuma. E o
+        // NOT EXISTS auto-referenciado pega so a acao MAIS RECENTE antes do pagamento, pra
+        // atribuir a recuperacao a quem era responsavel naquele momento, nao a quem e o
+        // cobrador atual do titulo (C."U_Cobrador" muda se o titulo for reatribuido depois).
+        listOf("cobranca-recuperado.sql", "cobranca-recuperado-adiantamento.sql").forEach { nome ->
+            val sql = views.getValue(nome)
+            assertTrue(sql.contains("INNER JOIN \"@COB_TITULO_L\" H"), "$nome nao junta com o historico")
+            assertTrue(sql.contains("H.\"Code\" = C.\"Code\" AND H.\"U_Data\" <= r.\"DocDate\""), nome)
+            assertTrue(
+                sql.contains("H2.\"U_Data\" > H.\"U_Data\" OR (H2.\"U_Data\" = H.\"U_Data\" AND H2.\"LineId\" > H.\"LineId\")"),
+                "$nome nao restringe a linha de historico mais recente antes do pagamento"
+            )
+            assertTrue(sql.contains("H.\"U_Cobrador\""), "$nome deve agrupar pelo cobrador da linha de historico, nao do mestre")
+            assertFalse(
+                sql.contains("C.\"U_Cobrador\""),
+                "$nome nao pode mais ler o cobrador do registro mestre - ele e mutavel e reflete a acao mais recente"
             )
         }
     }

--- a/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaEscopoTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaEscopoTest.kt
@@ -1,0 +1,42 @@
+package br.andrew.sap.services.cobranca
+
+import br.andrew.sap.model.authentication.User
+import br.andrew.sap.model.authentication.UserOriginEnum
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class CobrancaEscopoTest {
+
+    private fun usuario(id: String, roles: List<String>) = User(
+        id, "Fulano", UserOriginEnum.EmployeesInfo, "fulano",
+        bussinesPlace = listOf(), roles = roles
+    )
+
+    @Test
+    fun `admin ve o vendedor solicitado, sem restricao`() {
+        val admin = usuario("1", listOf("admin"))
+        assertEquals(42, CobrancaEscopo.vendedorEfetivo(admin, 42))
+        assertEquals(null, CobrancaEscopo.vendedorEfetivo(admin, null))
+    }
+
+    @Test
+    fun `vendedor_admin ve o vendedor solicitado, sem restricao`() {
+        val vendedorAdmin = usuario("2", listOf("vendedor_admin"))
+        assertEquals(42, CobrancaEscopo.vendedorEfetivo(vendedorAdmin, 42))
+        assertEquals(null, CobrancaEscopo.vendedorEfetivo(vendedorAdmin, null))
+    }
+
+    @Test
+    fun `cobranca sem SalesPersonCode vinculado ve o vendedor solicitado, nao e restringido pelo EmployeeID`() {
+        val cobranca = usuario("999", listOf("cobranca"))
+        assertEquals(42, CobrancaEscopo.vendedorEfetivo(cobranca, 42))
+        assertEquals(null, CobrancaEscopo.vendedorEfetivo(cobranca, null))
+    }
+
+    @Test
+    fun `vendedor comum e restringido ao proprio id, mesmo pedindo outro vendedor`() {
+        val vendedor = usuario("60", listOf("vendedor"))
+        assertEquals(60, CobrancaEscopo.vendedorEfetivo(vendedor, 999))
+        assertEquals(60, CobrancaEscopo.vendedorEfetivo(vendedor, null))
+    }
+}

--- a/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaServiceTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaServiceTest.kt
@@ -27,18 +27,25 @@ import org.springframework.http.HttpMethod
 import org.springframework.http.RequestEntity
 import org.springframework.http.ResponseEntity
 import org.springframework.web.client.RestTemplate
+import org.springframework.web.server.ResponseStatusException
 import java.net.URI
+import java.util.concurrent.atomic.AtomicReference
 
 class CobrancaServiceTest {
 
     private val restTemplate = mock<RestTemplate>()
     private val env = SapEnvrioment("https://sap.local", "manager", "senha", "SBODEMO")
     private val authService = AuthService(env, restTemplate)
-    private val service = CobrancaService(env, restTemplate, authService)
+    private val consultaService = mock<CobrancaConsultaService>()
+    private val service = CobrancaService(env, restTemplate, authService, consultaService)
 
     private val cobradora = User(
         "60", "Fulano de Tal", UserOriginEnum.SalePerson, "fulano",
         bussinesPlace = listOf(), roles = listOf("vendedor")
+    )
+    private val admin = User(
+        "1", "Admin", UserOriginEnum.EmployeesInfo, "admin",
+        bussinesPlace = listOf(), roles = listOf("admin")
     )
 
     @BeforeEach
@@ -201,6 +208,85 @@ class CobrancaServiceTest {
         assertFalse(resultado[1].success)
         assertEquals(2, resultado[1].docEntry)
         assertTrue(resultado[1].error?.isNotBlank() == true)
+    }
+
+    @Test
+    fun `duas acoes concorrentes no mesmo titulo nao perdem nenhuma linha de historico`() {
+        val estadoAtual = AtomicReference(
+            CobrancaRegistro(Code = "NF-500-1", U_Tipo = "NF", U_DocEntry = 500, U_InstlmntID = 1, historico = mutableListOf())
+        )
+
+        whenever(restTemplate.exchange(any<RequestEntity<*>>(), eq(OData::class.java)))
+            .thenAnswer { invocation ->
+                val request = invocation.getArgument<RequestEntity<*>>(0)
+                when (request.method) {
+                    HttpMethod.GET -> {
+                        Thread.sleep(20)
+                        ResponseEntity.ok(odataLista(listOf(estadoAtual.get())))
+                    }
+                    HttpMethod.PATCH -> {
+                        val corpo = request.body as Map<*, *>
+                        @Suppress("UNCHECKED_CAST")
+                        val novoHistorico = corpo["COB_TITULO_LCollection"] as MutableList<CobrancaHistorico>
+                        estadoAtual.set(estadoAtual.get().apply { historico = novoHistorico })
+                        ResponseEntity.ok(OData())
+                    }
+                    else -> throw AssertionError("Metodo inesperado: ${request.method}")
+                }
+            }
+
+        val cobradorA = User("60", "Cobrador A", UserOriginEnum.SalePerson, "a", bussinesPlace = listOf(), roles = listOf("vendedor"))
+        val cobradorB = User("61", "Cobrador B", UserOriginEnum.SalePerson, "b", bussinesPlace = listOf(), roles = listOf("vendedor"))
+
+        val threadA = Thread { service.registrarAcao("NF", 500, 1, CobrancaAcaoRequest(observacao = "acao A"), cobradorA) }
+        val threadB = Thread { service.registrarAcao("NF", 500, 1, CobrancaAcaoRequest(observacao = "acao B"), cobradorB) }
+        threadA.start()
+        threadB.start()
+        threadA.join()
+        threadB.join()
+
+        assertEquals(2, estadoAtual.get().historico.size, "as duas acoes concorrentes devem aparecer no historico final")
+    }
+
+    @Test
+    fun `vendedor comum ve o historico do proprio titulo`() {
+        whenever(consultaService.slpCodeDoTitulo("NF", 500)).thenReturn(60)
+        whenever(restTemplate.exchange(any<RequestEntity<*>>(), eq(OData::class.java)))
+            .thenReturn(ResponseEntity.ok(odataLista(listOf(CobrancaRegistro(Code = "NF-500-1", U_Tipo = "NF", U_DocEntry = 500, U_InstlmntID = 1)))))
+
+        val historico = service.historico(cobradora, "NF", 500, 1)
+
+        assertTrue(historico.isEmpty())
+    }
+
+    @Test
+    fun `vendedor comum nao ve historico de titulo de outro vendedor`() {
+        whenever(consultaService.slpCodeDoTitulo("NF", 500)).thenReturn(99)
+
+        assertThrows(ResponseStatusException::class.java) {
+            service.historico(cobradora, "NF", 500, 1)
+        }
+        verify(restTemplate, never()).exchange(any<RequestEntity<*>>(), eq(OData::class.java))
+    }
+
+    @Test
+    fun `vendedor comum nao ve historico de titulo que nao existe no SAP`() {
+        whenever(consultaService.slpCodeDoTitulo("NF", 500)).thenReturn(null)
+
+        assertThrows(ResponseStatusException::class.java) {
+            service.historico(cobradora, "NF", 500, 1)
+        }
+    }
+
+    @Test
+    fun `admin ve historico de qualquer titulo, sem consultar o SlpCode`() {
+        whenever(restTemplate.exchange(any<RequestEntity<*>>(), eq(OData::class.java)))
+            .thenReturn(ResponseEntity.ok(odataLista(emptyList<CobrancaRegistro>())))
+
+        val historico = service.historico(admin, "NF", 500, 1)
+
+        assertTrue(historico.isEmpty())
+        verify(consultaService, never()).slpCodeDoTitulo(any(), any())
     }
 
     private fun odataLista(value: List<Any?>): OData {

--- a/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaServiceTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaServiceTest.kt
@@ -8,6 +8,7 @@ import br.andrew.sap.model.cobranca.CobrancaAcaoRequest
 import br.andrew.sap.model.cobranca.CobrancaException
 import br.andrew.sap.model.cobranca.CobrancaHistorico
 import br.andrew.sap.model.cobranca.CobrancaRegistro
+import br.andrew.sap.model.cobranca.CobrancaTituloVendedorSap
 import br.andrew.sap.model.envrioments.SapEnvrioment
 import br.andrew.sap.model.sap.Session
 import br.andrew.sap.services.AuthService
@@ -52,6 +53,8 @@ class CobrancaServiceTest {
     fun mockLogin() {
         whenever(restTemplate.postForEntity(any<URI>(), any(), eq(Session::class.java)))
             .thenReturn(ResponseEntity.ok(Session("sessao-1", "10.0", 30)))
+        whenever(consultaService.buscarTituloParaEscopo(any(), any(), any()))
+            .thenReturn(CobrancaTituloVendedorSap(SlpCode = null))
     }
 
     @Test
@@ -250,7 +253,7 @@ class CobrancaServiceTest {
 
     @Test
     fun `vendedor comum ve o historico do proprio titulo`() {
-        whenever(consultaService.slpCodeDoTitulo("NF", 500)).thenReturn(60)
+        whenever(consultaService.buscarTituloParaEscopo("NF", 500, 1)).thenReturn(CobrancaTituloVendedorSap(SlpCode = 60))
         whenever(restTemplate.exchange(any<RequestEntity<*>>(), eq(OData::class.java)))
             .thenReturn(ResponseEntity.ok(odataLista(listOf(CobrancaRegistro(Code = "NF-500-1", U_Tipo = "NF", U_DocEntry = 500, U_InstlmntID = 1)))))
 
@@ -261,7 +264,7 @@ class CobrancaServiceTest {
 
     @Test
     fun `vendedor comum nao ve historico de titulo de outro vendedor`() {
-        whenever(consultaService.slpCodeDoTitulo("NF", 500)).thenReturn(99)
+        whenever(consultaService.buscarTituloParaEscopo("NF", 500, 1)).thenReturn(CobrancaTituloVendedorSap(SlpCode = 99))
 
         assertThrows(ResponseStatusException::class.java) {
             service.historico(cobradora, "NF", 500, 1)
@@ -271,7 +274,7 @@ class CobrancaServiceTest {
 
     @Test
     fun `vendedor comum nao ve historico de titulo que nao existe no SAP`() {
-        whenever(consultaService.slpCodeDoTitulo("NF", 500)).thenReturn(null)
+        whenever(consultaService.buscarTituloParaEscopo("NF", 500, 1)).thenReturn(null)
 
         assertThrows(ResponseStatusException::class.java) {
             service.historico(cobradora, "NF", 500, 1)
@@ -286,7 +289,25 @@ class CobrancaServiceTest {
         val historico = service.historico(admin, "NF", 500, 1)
 
         assertTrue(historico.isEmpty())
-        verify(consultaService, never()).slpCodeDoTitulo(any(), any())
+        verify(consultaService, never()).buscarTituloParaEscopo(any(), any(), any())
+    }
+
+    @Test
+    fun `recusa criar registro quando a parcela nao existe no SAP`() {
+        whenever(restTemplate.exchange(any<RequestEntity<*>>(), eq(OData::class.java)))
+            .thenAnswer { invocation ->
+                val request = invocation.getArgument<RequestEntity<*>>(0)
+                when (request.method) {
+                    HttpMethod.GET -> ResponseEntity.ok(odataLista(emptyList<CobrancaRegistro>()))
+                    else -> throw AssertionError("Nao deveria criar nada para uma parcela que nao existe: ${request.method}")
+                }
+            }
+        whenever(consultaService.buscarTituloParaEscopo("NF", 999, 1)).thenReturn(null)
+
+        val req = CobrancaAcaoRequest(observacao = "teste")
+        assertThrows(CobrancaException::class.java) {
+            service.registrarAcao("NF", 999, 1, req, cobradora)
+        }
     }
 
     private fun odataLista(value: List<Any?>): OData {

--- a/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaServiceTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaServiceTest.kt
@@ -1,0 +1,215 @@
+package br.andrew.sap.services.cobranca
+
+import br.andrew.sap.infrastructure.odata.OData
+import br.andrew.sap.model.authentication.User
+import br.andrew.sap.model.authentication.UserOriginEnum
+import br.andrew.sap.model.cobranca.CobrancaAcaoLoteItem
+import br.andrew.sap.model.cobranca.CobrancaAcaoRequest
+import br.andrew.sap.model.cobranca.CobrancaException
+import br.andrew.sap.model.cobranca.CobrancaHistorico
+import br.andrew.sap.model.cobranca.CobrancaRegistro
+import br.andrew.sap.model.envrioments.SapEnvrioment
+import br.andrew.sap.model.sap.Session
+import br.andrew.sap.services.AuthService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.never
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpMethod
+import org.springframework.http.RequestEntity
+import org.springframework.http.ResponseEntity
+import org.springframework.web.client.RestTemplate
+import java.net.URI
+
+class CobrancaServiceTest {
+
+    private val restTemplate = mock<RestTemplate>()
+    private val env = SapEnvrioment("https://sap.local", "manager", "senha", "SBODEMO")
+    private val authService = AuthService(env, restTemplate)
+    private val service = CobrancaService(env, restTemplate, authService)
+
+    private val cobradora = User(
+        "60", "Fulano de Tal", UserOriginEnum.SalePerson, "fulano",
+        bussinesPlace = listOf(), roles = listOf("vendedor")
+    )
+
+    @BeforeEach
+    fun mockLogin() {
+        whenever(restTemplate.postForEntity(any<URI>(), any(), eq(Session::class.java)))
+            .thenReturn(ResponseEntity.ok(Session("sessao-1", "10.0", 30)))
+    }
+
+    @Test
+    fun `gera o Code a partir do tipo, docEntry e da parcela`() {
+        assertEquals("NF-500-1", CobrancaRegistro.code("NF", 500, 1))
+        assertEquals("AD-500-1", CobrancaRegistro.code("AD", 500, 1))
+    }
+
+    @Test
+    fun `recusa tipo de titulo invalido`() {
+        val req = CobrancaAcaoRequest(observacao = "teste")
+        assertThrows(CobrancaException::class.java) {
+            service.registrarAcao("XX", 500, 1, req, cobradora)
+        }
+        verify(restTemplate, never()).exchange(any<RequestEntity<*>>(), eq(OData::class.java))
+    }
+
+    @Test
+    fun `recusa registrar acao sem observacao e sem ocorrencia`() {
+        val req = CobrancaAcaoRequest(status = "8 - EM NEGOCIAÇÃO")
+
+        assertThrows(CobrancaException::class.java) {
+            service.registrarAcao("NF", 500, 1, req, cobradora)
+        }
+        verify(restTemplate, never()).exchange(any<RequestEntity<*>>(), eq(OData::class.java))
+    }
+
+    @Test
+    fun `cria o registro quando ele ainda nao existe e carimba o cobrador e a data`() {
+        whenever(restTemplate.exchange(any<RequestEntity<*>>(), eq(OData::class.java)))
+            .thenAnswer { invocation ->
+                val request = invocation.getArgument<RequestEntity<*>>(0)
+                when (request.method) {
+                    HttpMethod.GET -> ResponseEntity.ok(odataLista(emptyList<CobrancaRegistro>()))
+                    HttpMethod.POST -> ResponseEntity.ok(odataFlat("Code" to "NF-500-1"))
+                    else -> throw AssertionError("Metodo inesperado: ${request.method}")
+                }
+            }
+
+        val req = CobrancaAcaoRequest(status = "8 - EM NEGOCIAÇÃO", observacao = "cliente prometeu pagar")
+        val registro = service.registrarAcao("NF", 500, 1, req, cobradora)
+
+        assertEquals("NF-500-1", registro.Code)
+
+        val captor = org.mockito.kotlin.argumentCaptor<RequestEntity<*>>()
+        verify(restTemplate, org.mockito.Mockito.times(2)).exchange(captor.capture(), eq(OData::class.java))
+        val corpoCriado = captor.allValues.first { it.method == HttpMethod.POST }.body as CobrancaRegistro
+
+        assertEquals("Fulano de Tal", corpoCriado.U_Cobrador)
+        assertEquals(1, corpoCriado.historico.size)
+        assertEquals("Fulano de Tal", corpoCriado.historico.first().U_Usuario)
+    }
+
+    @Test
+    fun `atualiza o registro existente sem apagar o historico anterior e ignora cobrador que o cliente nao pode enviar`() {
+        val linhaAntiga = CobrancaHistorico(
+            U_Data = "2026-07-01", U_Usuario = "Nilvia", U_Cobrador = "Nilvia", U_Status = "3 - SEM CONTATO"
+        ).also { it.LineId = 1 }
+        val existente = CobrancaRegistro(
+            Code = "NF-500-1", U_Tipo = "NF", U_DocEntry = 500, U_InstlmntID = 1, U_Status = "3 - SEM CONTATO",
+            historico = mutableListOf(linhaAntiga)
+        )
+        val depoisDoPatch = CobrancaRegistro(
+            Code = "NF-500-1", U_Tipo = "NF", U_DocEntry = 500, U_InstlmntID = 1, U_Status = "9 - ACORDO ENVIADO",
+            U_Cobrador = "Fulano de Tal",
+            historico = mutableListOf(
+                linhaAntiga,
+                CobrancaHistorico("2026-07-27", "Fulano de Tal", "Fulano de Tal", U_Status = "9 - ACORDO ENVIADO")
+                    .also { it.LineId = 2 }
+            )
+        )
+
+        var chamadasGet = 0
+        var corpoPatch: Map<*, *>? = null
+        whenever(restTemplate.exchange(any<RequestEntity<*>>(), eq(OData::class.java)))
+            .thenAnswer { invocation ->
+                val request = invocation.getArgument<RequestEntity<*>>(0)
+                when (request.method) {
+                    HttpMethod.GET -> {
+                        chamadasGet++
+                        ResponseEntity.ok(odataLista(if (chamadasGet == 1) listOf(existente) else listOf(depoisDoPatch)))
+                    }
+                    HttpMethod.PATCH -> {
+                        corpoPatch = request.body as Map<*, *>
+                        ResponseEntity.ok(OData())
+                    }
+                    else -> throw AssertionError("Metodo inesperado: ${request.method}")
+                }
+            }
+
+        val req = CobrancaAcaoRequest(status = "9 - ACORDO ENVIADO", observacao = "cliente confirmou pagamento")
+        val registro = service.registrarAcao("NF", 500, 1, req, cobradora)
+
+        assertEquals("9 - ACORDO ENVIADO", registro.U_Status)
+        assertEquals(2, registro.historico.size)
+        assertEquals("Fulano de Tal", corpoPatch!!["U_Cobrador"])
+
+        val historicoEnviado = corpoPatch!!["COB_TITULO_LCollection"] as List<*>
+        assertEquals(2, historicoEnviado.size, "a linha antiga precisa ser reenviada, senao o PATCH apaga o historico")
+    }
+
+    @Test
+    fun `campo deixado em branco fica de fora do PATCH em vez de ser enviado como null`() {
+        val existente = CobrancaRegistro(
+            Code = "NF-500-1", U_Tipo = "NF", U_DocEntry = 500, U_InstlmntID = 1,
+            U_Status = "3 - SEM CONTATO", U_Acao = "4 - LIGAÇÃO",
+            historico = mutableListOf()
+        )
+
+        var corpoPatch: Map<*, *>? = null
+        whenever(restTemplate.exchange(any<RequestEntity<*>>(), eq(OData::class.java)))
+            .thenAnswer { invocation ->
+                val request = invocation.getArgument<RequestEntity<*>>(0)
+                when (request.method) {
+                    HttpMethod.GET -> ResponseEntity.ok(odataLista(listOf(existente)))
+                    HttpMethod.PATCH -> {
+                        corpoPatch = request.body as Map<*, *>
+                        ResponseEntity.ok(OData())
+                    }
+                    else -> throw AssertionError("Metodo inesperado: ${request.method}")
+                }
+            }
+
+        //so envia observacao; status e acao ficam de fora do request (usuario nao mexeu neles)
+        val req = CobrancaAcaoRequest(observacao = "cliente ligou de volta")
+        service.registrarAcao("NF", 500, 1, req, cobradora)
+
+        assertFalse(corpoPatch!!.containsKey("U_Status"), "campo nao informado nao pode ser enviado (nem como null)")
+        assertFalse(corpoPatch!!.containsKey("U_Acao"), "campo nao informado nao pode ser enviado (nem como null)")
+        assertEquals("cliente ligou de volta", corpoPatch!!["U_Observacao"])
+    }
+
+    @Test
+    fun `lote isola erro por item sem interromper os demais`() {
+        whenever(restTemplate.exchange(any<RequestEntity<*>>(), eq(OData::class.java)))
+            .thenAnswer { invocation ->
+                val request = invocation.getArgument<RequestEntity<*>>(0)
+                when (request.method) {
+                    HttpMethod.GET -> ResponseEntity.ok(odataLista(emptyList<CobrancaRegistro>()))
+                    HttpMethod.POST -> ResponseEntity.ok(odataFlat("Code" to "NF-1-1"))
+                    else -> throw AssertionError("Metodo inesperado: ${request.method}")
+                }
+            }
+
+        val itens = listOf(
+            CobrancaAcaoLoteItem(tipo = "NF", docEntry = 1, instlmntId = 1, status = "8 - EM NEGOCIAÇÃO", observacao = "ok"),
+            CobrancaAcaoLoteItem(tipo = "NF", docEntry = 2, instlmntId = 1), // sem observacao nem ocorrencia -> deve falhar
+        )
+
+        val resultado = service.registrarAcaoEmLote(itens, cobradora)
+
+        assertEquals(2, resultado.size)
+        assertTrue(resultado[0].success)
+        assertFalse(resultado[1].success)
+        assertEquals(2, resultado[1].docEntry)
+        assertTrue(resultado[1].error?.isNotBlank() == true)
+    }
+
+    private fun odataLista(value: List<Any?>): OData {
+        val backing = LinkedHashMap<String, Any?>()
+        backing["value"] = value
+        return OData(backing)
+    }
+
+    private fun odataFlat(vararg pares: Pair<String, Any?>): OData {
+        return OData(LinkedHashMap(pares.toMap()))
+    }
+}

--- a/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaTituloSerializacaoTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaTituloSerializacaoTest.kt
@@ -1,0 +1,38 @@
+package br.andrew.sap.services.cobranca
+
+import br.andrew.sap.model.cobranca.CobrancaTitulo
+import com.fasterxml.jackson.databind.json.JsonMapper
+import com.fasterxml.jackson.module.kotlin.kotlinModule
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class CobrancaTituloSerializacaoTest {
+
+    @Test
+    fun `BPLId e BPLName sobrevivem a serializacao pro front com o nome exato esperado`() {
+        // Sem @JsonProperty explicito, o UpperCamelCaseStrategy transforma esses dois
+        // campos (3+ maiusculas seguidas no inicio) em "Bplid"/"Bplname" na saida, e o
+        // front (que espera "BPLId"/"BPLName" literal) nunca acha o valor - foi assim
+        // que a coluna Filial ficou em branco em producao. Trava esse comportamento aqui.
+        val titulo = CobrancaTitulo(
+            Tipo = "NF", DocEntry = 1, DocNum = 534, Serial = "1", Series = 1,
+            BPLId = 6, BPLName = "FAZENDA SERRA VERDE",
+            CardCode = "CLI0007196", CardName = "GILBERTO", DocDate = "20260401",
+            DocTotal = BigDecimal("100.00"), SlpCode = 60, SlpName = "Agro Pasto",
+            InstlmntID = 1, InsTotal = BigDecimal("100.00"), PaidToDate = BigDecimal.ZERO,
+            DueDate = "20260701", Saldo = BigDecimal("100.00"), DiasAtraso = 30, SituacaoSap = "ABERTO",
+            U_Status = null, U_Cobrador = null, U_Acao = null, U_Situacao = null,
+            U_Ocorrencia = null, U_Observacao = null, U_DataAcao = null, U_DataPromessa = null,
+        )
+
+        val mapper = JsonMapper.builder().addModule(kotlinModule()).build()
+        val json = mapper.writeValueAsString(titulo)
+
+        assertTrue(json.contains("\"BPLId\":6"), "BPLId nao saiu com o nome exato esperado! JSON: $json")
+        assertTrue(json.contains("\"BPLName\":\"FAZENDA SERRA VERDE\""), "BPLName nao saiu com o nome exato esperado! JSON: $json")
+        assertFalse(json.contains("\"Bplid\""), "voltou a sair com o nome mangled pelo UpperCamelCaseStrategy")
+        assertFalse(json.contains("\"Bplname\""), "voltou a sair com o nome mangled pelo UpperCamelCaseStrategy")
+    }
+}

--- a/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaTitulosSqlTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaTitulosSqlTest.kt
@@ -201,4 +201,9 @@ class TitulosEmailSqlTest {
             "nao deve mais ler o UDF antigo do INV6"
         )
     }
+
+    @Test
+    fun `usa o Tipo NF ao juntar com a UDT, pra nao colidir com adiantamento de mesmo DocEntry`() {
+        assertTrue(sql.contains("C.\"U_Tipo\" = 'NF'"))
+    }
 }

--- a/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaTitulosSqlTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaTitulosSqlTest.kt
@@ -1,0 +1,184 @@
+package br.andrew.sap.services.cobranca
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+class CobrancaTitulosSqlTest {
+
+    private val sql = Files.readString(
+        Path.of("src/main/resources/views/cobranca/cobranca-titulos.sql")
+    )
+
+    @Test
+    fun `nao reintroduz a lista fixa de filiais do titulos-sql`() {
+        assertFalse(
+            sql.contains("BPLId\" in ("),
+            "filial deve ser filtro opcional (x = :filial OR x < :filialIsFilter), nao uma lista fixa de BPLId"
+        )
+    }
+
+    @Test
+    fun `mantem visivel o titulo que ja esta em acompanhamento mesmo apos a baixa`() {
+        assertTrue(
+            sql.contains("OR C.\"Code\" IS NOT NULL"),
+            "sem essa clausula a parcela some da lista assim que e paga, perdendo o historico de cobranca"
+        )
+    }
+
+    @Test
+    fun `escopo deliberado - titulo quitado que nunca precisou de cobranca fica de fora da consulta`() {
+        // Decisao consciente (nao e bug): manter P."Status" = 'O' como parte do primeiro braco
+        // do OR significa que um titulo ja fechado no SAP e que NUNCA teve @COB_TITULO (C.Code
+        // IS NULL) nao passa por nenhum dos dois lados do OR - nunca chega no Kotlin. Por isso o
+        // filtro "Situacao SAP = Pago/Todos" so mostra titulo que ja foi acompanhado; nao e um
+        // extrato geral de notas fiscais quitadas. Se um dia isso precisar mudar, e uma decisao
+        // de escopo (custo de volume/performance ao abrir a consulta pra todo o historico do
+        // SAP), nao um ajuste trivial de filtro.
+        assertTrue(sql.contains("P.\"Status\" = 'O'"))
+    }
+
+    @Test
+    fun `le o acompanhamento da UDT, nunca dos UDFs do INV6`() {
+        assertFalse(sql.contains("P.\"U_StatusCobranca\""))
+        assertFalse(sql.contains("P.\"U_AgenteCobrador\""))
+        assertTrue(sql.contains("LEFT JOIN \"@COB_TITULO\" C"))
+    }
+
+    @Test
+    fun `usa o Tipo NF ao juntar com a UDT, pra nao colidir com adiantamento de mesmo DocEntry`() {
+        assertTrue(sql.contains("C.\"U_Tipo\" = 'NF'"))
+    }
+
+    @Test
+    fun `expoe o status oficial da parcela para SituacaoSap nao depender do saldo calculado`() {
+        // Saldo (InsTotal - PaidToDate) pode dar negativo por rateio/adiantamento vinculado
+        // mesmo com a parcela ainda aberta no SAP - SituacaoSap tem que vir do Status real.
+        assertTrue(sql.contains("P.\"Status\" AS \"StatusParcela\""))
+    }
+
+    @Test
+    fun `filtros opcionais de filial, vendedor e cliente seguem o idioma x-ou-xIsFilter`() {
+        assertTrue(sql.contains(":filialIsFilter"))
+        assertTrue(sql.contains(":vendedorIsFilter"))
+        assertTrue(sql.contains(":clienteIsFilter"))
+    }
+
+    @Test
+    fun `situacao e intervalo de vencimento sao filtrados no SQL, nao em Kotlin`() {
+        // Filtro resolvido so em Kotlin e aplicado DEPOIS de a linha vir do SAP, e o laco de
+        // paginacao de CobrancaConsultaService busca pagina nova ate juntar linha aprovada
+        // suficiente - filtro seletivo fora do SQL faz o backend varrer a base de 20 em 20.
+        assertTrue(sql.contains(":statusParcelaIsFilter"))
+        assertTrue(sql.contains(":vencimentoDe"))
+        assertTrue(sql.contains(":vencimentoAte"))
+    }
+
+    @Test
+    fun `filtro de campo da UDT usa coluna nao-nula como escape, nunca a propria coluna nula`() {
+        // C."U_Status" vem de LEFT JOIN: e nulo pra titulo nunca acompanhado. Se o "desligado"
+        // fosse testado nele (C."U_Status" < :statusIsFilter), NULL < valor seria desconhecido
+        // e TODO titulo nunca acompanhado sumiria da tela. O escape tem que ser uma coluna que
+        // nunca e nula - aqui o DocEntry da propria fatura.
+        assertTrue(sql.contains("C.\"U_Status\"    = :status   OR NS.\"DocEntry\" < :statusIsFilter"))
+        assertTrue(sql.contains("C.\"U_Cobrador\"  = :cobrador OR NS.\"DocEntry\" < :cobradorIsFilter"))
+        assertTrue(sql.contains("C.\"U_Situacao\"  = :situacao OR NS.\"DocEntry\" < :situacaoIsFilter"))
+        assertFalse(
+            sql.contains("C.\"U_Status\" < :statusIsFilter"),
+            "escape em coluna de LEFT JOIN faria o titulo nunca acompanhado desaparecer"
+        )
+    }
+
+    @Test
+    fun `nao usa funcoes que o parser do SQLQueries do SAP B1 nao reconhece nesse contexto`() {
+        // Saldo, DiasAtraso e SituacaoSap sao calculados em Kotlin (CobrancaTituloSap.toDto);
+        // IFNULL/DAYS_BETWEEN/CASE WHEN aqui ja quebraram o provisionamento em producao
+        // ("mismatched input '.' expecting FROM") por nao terem precedente nas views existentes.
+        assertFalse(sql.contains("IFNULL"))
+        assertFalse(sql.contains("DAYS_BETWEEN"))
+        assertFalse(sql.contains("CASE WHEN"))
+        assertFalse(sql.contains("CURRENT_DATE"))
+    }
+}
+
+class CobrancaTitulosAdiantamentoSqlTest {
+
+    private val sql = Files.readString(
+        Path.of("src/main/resources/views/cobranca/cobranca-titulos-adiantamento.sql")
+    )
+
+    @Test
+    fun `usa o Tipo AD ao juntar com a UDT, pra nao colidir com fatura de mesmo DocEntry`() {
+        // ODPI (adiantamento) e OINV (fatura) tem contadores de DocEntry independentes no
+        // SAP (ObjType 203 x 13) - sem o Tipo na chave, os dois colidiriam em @COB_TITULO.
+        assertTrue(sql.contains("C.\"U_Tipo\" = 'AD'"))
+    }
+
+    @Test
+    fun `expoe o status oficial da parcela para SituacaoSap nao depender do saldo calculado`() {
+        assertTrue(sql.contains("P.\"Status\" AS \"StatusParcela\""))
+    }
+
+    @Test
+    fun `liga o adiantamento ao contrato de venda futura pelo U_venda_futura`() {
+        assertTrue(sql.contains("\"@AR_CONTRATO_FUTURO\""))
+        assertTrue(sql.contains("T0.\"U_venda_futura\""))
+    }
+
+    @Test
+    fun `mantem visivel o adiantamento que ja esta em acompanhamento mesmo apos a baixa`() {
+        assertTrue(sql.contains("OR C.\"Code\" IS NOT NULL"))
+    }
+
+    @Test
+    fun `filtros opcionais seguem o mesmo idioma x-ou-xIsFilter da query de faturas`() {
+        assertTrue(sql.contains(":filialIsFilter"))
+        assertTrue(sql.contains(":vendedorIsFilter"))
+        assertTrue(sql.contains(":clienteIsFilter"))
+    }
+
+    @Test
+    fun `situacao e intervalo de vencimento tambem sao filtrados no SQL aqui`() {
+        // As duas queries recebem a MESMA lista de parametros em CobrancaConsultaService -
+        // se uma view deixar de aceitar um parametro, a consulta quebra pro tipo dela.
+        assertTrue(sql.contains(":statusParcelaIsFilter"))
+        assertTrue(sql.contains(":vencimentoDe"))
+        assertTrue(sql.contains(":vencimentoAte"))
+    }
+
+    @Test
+    fun `filtro de campo da UDT tambem usa coluna nao-nula como escape aqui`() {
+        assertTrue(sql.contains("C.\"U_Status\"    = :status   OR T0.\"DocEntry\" < :statusIsFilter"))
+        assertTrue(sql.contains("C.\"U_Cobrador\"  = :cobrador OR T0.\"DocEntry\" < :cobradorIsFilter"))
+        assertTrue(sql.contains("C.\"U_Situacao\"  = :situacao OR T0.\"DocEntry\" < :situacaoIsFilter"))
+    }
+
+    @Test
+    fun `nao usa UNION, COALESCE ou CAST - sem precedente no parser do SQLQueries do SAP B1`() {
+        assertFalse(sql.contains("UNION"))
+        assertFalse(sql.contains("COALESCE"))
+        assertFalse(sql.contains("CAST("))
+        assertFalse(sql.contains("IFNULL"))
+    }
+}
+
+class TitulosEmailSqlTest {
+
+    private val sql = Files.readString(Path.of("src/main/resources/views/titulos.sql"))
+
+    @Test
+    fun `email semanal passa a ler o status e o cobrador da UDT de cobranca`() {
+        assertTrue(sql.contains("C.\"U_Status\" AS \"U_StatusCobranca\""))
+        assertTrue(sql.contains("C.\"U_Cobrador\" AS \"U_AgenteCobrador\""))
+        assertFalse(
+            sql.contains("P.\"U_StatusCobranca\""),
+            "nao deve mais ler o UDF antigo do INV6"
+        )
+        assertFalse(
+            sql.contains("P.\"U_AgenteCobrador\""),
+            "nao deve mais ler o UDF antigo do INV6"
+        )
+    }
+}

--- a/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaTitulosSqlTest.kt
+++ b/src/test/kotlin/br/andrew/sap/services/cobranca/CobrancaTitulosSqlTest.kt
@@ -92,6 +92,19 @@ class CobrancaTitulosSqlTest {
     }
 
     @Test
+    fun `filtros do drill-down do dashboard tambem escapam em coluna nao-nula`() {
+        // "Sem nenhuma acao" e presenca/ausencia de registro na UDT, e promessa vencida le uma
+        // coluna do LEFT JOIN - os dois sao nulos pro titulo nunca acompanhado. Se o escape
+        // fosse na propria coluna, ligar QUALQUER outro filtro faria esses titulos sumirem.
+        assertTrue(sql.contains("C.\"Code\" IS NULL OR NS.\"DocEntry\" < :semAcompanhamentoIsFilter"))
+        assertTrue(sql.contains("C.\"U_DataPromessa\" <= :promessaVencidaAte OR NS.\"DocEntry\" < :promessaVencidaIsFilter"))
+        assertFalse(
+            sql.contains("C.\"U_DataPromessa\" < :promessaVencidaIsFilter"),
+            "escape em coluna de LEFT JOIN faria o titulo sem promessa desaparecer"
+        )
+    }
+
+    @Test
     fun `nao usa funcoes que o parser do SQLQueries do SAP B1 nao reconhece nesse contexto`() {
         // Saldo, DiasAtraso e SituacaoSap sao calculados em Kotlin (CobrancaTituloSap.toDto);
         // IFNULL/DAYS_BETWEEN/CASE WHEN aqui ja quebraram o provisionamento em producao
@@ -153,6 +166,13 @@ class CobrancaTitulosAdiantamentoSqlTest {
         assertTrue(sql.contains("C.\"U_Status\"    = :status   OR T0.\"DocEntry\" < :statusIsFilter"))
         assertTrue(sql.contains("C.\"U_Cobrador\"  = :cobrador OR T0.\"DocEntry\" < :cobradorIsFilter"))
         assertTrue(sql.contains("C.\"U_Situacao\"  = :situacao OR T0.\"DocEntry\" < :situacaoIsFilter"))
+    }
+
+    @Test
+    fun `os filtros do drill-down existem aqui tambem, senao a consulta quebra pro adiantamento`() {
+        // As duas views recebem a MESMA lista de parametros em CobrancaConsultaService.
+        assertTrue(sql.contains("C.\"Code\" IS NULL OR T0.\"DocEntry\" < :semAcompanhamentoIsFilter"))
+        assertTrue(sql.contains("C.\"U_DataPromessa\" <= :promessaVencidaAte OR T0.\"DocEntry\" < :promessaVencidaIsFilter"))
     }
 
     @Test


### PR DESCRIPTION
> A branch tem mais arquivos no diff do que só a feature de cobrança (trabalho de outras frentes entrou via merge da master). Este resumo cobre especificamente a parte de Cobrança.

**Resumo**
Novo módulo de Cobrança: acompanhamento de títulos em atraso (nota fiscal e adiantamento), com registro de ação por cobrador e um dashboard de indicadores.

**O que mudou**
- **UDTs novas no SAP**: `@COB_TITULO` (+ linha de histórico `@COB_TITULO_L`) guarda status/ação/situação/ocorrência/cobrador/promessa por parcela; `@COB_DOMINIO` guarda os valores desses domínios, editáveis direto no SAP sem precisar de deploy.
- **Endpoints**: `GET /cobranca/titulos` (lista paginada, ~12 filtros), `GET .../historico`, `POST .../acao` e `POST /cobranca/titulos/acoes` (lote), `GET /cobranca/dashboard` e `.../dashboard/evolucao`, `GET`/`POST /cobranca/dominios`.
- **14 views SQL** (nota fiscal + adiantamento sempre em par): carteira, recuperado, recuperado diário, sem ação, promessa vencida, trabalhados, títulos — separadas porque `UNION` e `CASE` não passam no parser do SQLQueries do SAP.
- **Exclusão de cliente-filial**: título cujo cliente é o `DflCust` (cliente padrão) de alguma filial do próprio sistema — movimentação interna — não entra em nenhuma consulta.
- **Desempenho**: busca de faturas e adiantamentos para o dashboard e a lista para de paginar assim que junta o suficiente pra página pedida, em vez de varrer a view inteira sempre.
- **Cache** de 5 min no dashboard, limpo na hora quando uma ação é registrada (individual ou em lote).
- **84 testes** (`CobrancaServiceTest`, `CobrancaConsultaServiceTest`, `CobrancaDashboardServiceTest`, `CobrancaDashboardSqlTest`, `CobrancaTitulosSqlTest`, `CobrancaTitulosAdiantamentoSqlTest`, `CobrancaTituloSerializacaoTest`).

- **Correção**: Reprocessamento.getReverseSaida lançava ArithmeticException quando a divisão dava dízima periódica (sem escala/RoundingMode), mascarando o erro original no fluxo de estorno de ReprocessamentoController/ContratoVendaFuturaController e deixando o estoque sem reverter. Ajustado pra escala 4 com HALF_DOWN, igual já era feito em getEntrada.

**Como testar**
- `./gradlew test --tests "*Cobranca*"` → 84 testes, 0 falhas.
- Subir a app e confirmar no log que as 14 views de cobrança provisionam sem erro (`ProvisioningConfiguration`).
- `POST /cobranca/titulos/NF/{docEntry}/{instlmntId}/acao` e conferir que `GET /cobranca/dashboard` reflete a mudança na próxima chamada (cache já invalidado).
